### PR TITLE
Chat input now uses a dark background

### DIFF
--- a/src/app/components/chat/window/send/send.styl
+++ b/src/app/components/chat/window/send/send.styl
@@ -16,7 +16,7 @@ textarea
 	color: $white
 
 	@media $media-sm-up
-		border: 1px solid $gray-dark
+		background-color: $gray-dark
 
 .-button
 	display: none


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6004491/29196079-1aaba4f4-7e2a-11e7-80de-d21e2c6461dd.png)
