### PR TITLE
Add margin to "X New Items" button in feed on mobile

### DIFF
--- a/src/app/components/activity/feed/new-button/new-button.vue
+++ b/src/app/components/activity/feed/new-button/new-button.vue
@@ -9,7 +9,6 @@
 <style lang="stylus" scoped>
 @require '../variables'
 @require '~styles-lib/mixins'
-@require '~styles/variables'
 
 .-container
 	padding-bottom: $-item-padding-v

--- a/src/app/components/activity/feed/new-button/new-button.vue
+++ b/src/app/components/activity/feed/new-button/new-button.vue
@@ -9,10 +9,10 @@
 <style lang="stylus" scoped>
 @require '../variables'
 @require '~styles-lib/mixins'
+@require '~styles/variables'
 
 .-container
-	@media $media-sm-up
-		padding-bottom: $-item-padding-v
+	padding-bottom: $-item-padding-v
 
 .-button
 	-activity-feed-item()


### PR DESCRIPTION
On mobile the button was directly attached to the top post in the feed, without any border or margin.