### PR TITLE
Center the searchbar within the top nav.

### DIFF
--- a/src/_common/nav/navbar/navbar.styl
+++ b/src/_common/nav/navbar/navbar.styl
@@ -73,18 +73,17 @@ $navbar-height = $shell-top-nav-height is defined ? $shell-top-nav-height : 50px
 		vertical-align: bottom
 
 .navbar-form
+	display: flex
+	align-items: center
+	justify-content: center
 	padding: 0
-	padding-right: 20px
 	width: 100%
 	height: $navbar-height
 	overflow: hidden
 
 	.form-control
-		border: 0
-		background-color: transparent
-		color: $white
+		border-width: 0
 		width: 100%
-		height: $navbar-height
 
 .navbar-controls
 	margin-top: ($navbar-height - $button-md-line-height) * 0.5
@@ -93,7 +92,7 @@ $navbar-height = $shell-top-nav-height is defined ? $shell-top-nav-height : 50px
 /**
  * Hover/active state underline.
  */
-.navbar-items > li > a, .navbar-item, .navbar-form-control, .navbar-avatar
+.navbar-items > li > a, .navbar-item, .navbar-avatar
 	position: relative
 
 	&::before

--- a/src/_common/observe-dimensions/observe-dimensions.directive.ts
+++ b/src/_common/observe-dimensions/observe-dimensions.directive.ts
@@ -1,0 +1,19 @@
+import { ResizeObserver } from 'resize-observer';
+import { DirectiveOptions } from 'vue';
+
+const observers = new WeakMap<HTMLElement, ResizeObserver>();
+
+export const AppObserveDimensions: DirectiveOptions = {
+	inserted(el, binding) {
+		const observer = new ResizeObserver(binding.value);
+		observer.observe(el);
+		observers.set(el, observer);
+	},
+	unbind(el) {
+		const observer = observers.get(el);
+		if (observer) {
+			observer.disconnect();
+			observers.delete(el);
+		}
+	},
+};

--- a/src/app/components/search/input/input.vue
+++ b/src/app/components/search/input/input.vue
@@ -13,10 +13,4 @@
 	/>
 </template>
 
-<style lang="stylus" scoped>
-// Gotta make room for the search history icon
-.search-input
-	padding-left: 40px
-</style>
-
 <script lang="ts" src="./input"></script>

--- a/src/app/components/search/search.vue
+++ b/src/app/components/search/search.vue
@@ -12,10 +12,10 @@
 				</label>
 
 				<!--
-				We use the 'click-show' trigger event.
-				This will make sure that the autocomplete popover doesn't disappear when
-				clicking the search input again.'
-			-->
+					We use the 'click-show' trigger event.
+					This will make sure that the autocomplete popover doesn't disappear when
+					clicking the search input again.'
+				-->
 				<app-popper
 					trigger="manual"
 					block

--- a/src/app/components/search/search.vue
+++ b/src/app/components/search/search.vue
@@ -2,69 +2,48 @@
 	<div class="app-search">
 		<app-shortkey shortkey="s" @press="focus" />
 
-		<app-jolticon class="-icon" icon="search" />
-
 		<!--
 			Put the action/method stuff so that crawlers can see how to submit the form.
 		-->
-		<form
-			class="search-input-form navbar-form"
-			action="/search"
-			method="GET"
-			role="search"
-			onsubmit="return false"
-		>
-			<div class="form-group">
+		<form class="navbar-form" action="/search" method="GET" role="search" onsubmit="return false">
+			<div class="-input">
 				<label :for="`search-input-${id}`" class="sr-only">
 					<translate>search.input.placeholder</translate>
 				</label>
 
-				<div class="navbar-form-control" :class="{ active: isFocused }">
-					<!--
-						We use the 'click-show' trigger event.
-						This will make sure that the autocomplete popover doesn't disappear when
-						clicking the search input again.'
-					-->
-					<app-popper
-						trigger="manual"
-						block
-						hide-on-state-change
-						track-trigger-width
-						:show="isShowingAutocomplete"
-						:disabled="autocompleteDisabled"
-						:auto-hide="false"
-					>
-						<app-search-input
-							:id="`search-input-${id}`"
-							ref="searchInput"
-							v-model="query"
-							@focus="onFocus"
-							@blur="onBlur"
-							@keydown="onKeydown"
-						/>
+				<!--
+				We use the 'click-show' trigger event.
+				This will make sure that the autocomplete popover doesn't disappear when
+				clicking the search input again.'
+			-->
+				<app-popper
+					trigger="manual"
+					block
+					hide-on-state-change
+					track-trigger-width
+					:show="isShowingAutocomplete"
+					:disabled="autocompleteDisabled"
+					:auto-hide="false"
+				>
+					<app-search-input
+						:id="`search-input-${id}`"
+						ref="searchInput"
+						v-model="query"
+						@focus="onFocus"
+						@blur="onBlur"
+						@keydown="onKeydown"
+					/>
 
-						<app-search-autocomplete slot="popover" />
-					</app-popper>
-				</div>
+					<app-search-autocomplete slot="popover" />
+				</app-popper>
 			</div>
 		</form>
 	</div>
 </template>
 
 <style lang="stylus" scoped>
-@require '~styles/variables'
-
-.app-search
-	position: relative
-
-.-icon
-	display: block
-	position: absolute
-	left: 5px
-	top: 16px
-	user-select: none
-	color: $dark-theme-fg-muted
-	z-index: 2
+.-input
+	width: 100%
 </style>
 
 <script lang="ts" src="./search"></script>

--- a/src/app/components/shell/top-nav/top-nav.ts
+++ b/src/app/components/shell/top-nav/top-nav.ts
@@ -102,7 +102,7 @@ export default class AppShellTopNav extends Vue {
 			return;
 		}
 
-		// Page content is centered within a column that is offset by the cbar,
+		// Page content is centered within a column that is offset by the cbar (value of $shell-cbar-width),
 		// so this does the same offseting within the top nav for the search bar
 		// to align properly in the center with the page content.
 		if (this.hasCbar) {

--- a/src/app/components/shell/top-nav/top-nav.ts
+++ b/src/app/components/shell/top-nav/top-nav.ts
@@ -1,13 +1,14 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import { Action, State } from 'vuex-class';
 import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { Connection } from '../../../../_common/connection/connection-service';
 import { Environment } from '../../../../_common/environment/environment.service';
+import { AppObserveDimensions } from '../../../../_common/observe-dimensions/observe-dimensions.directive';
 import AppPopper from '../../../../_common/popper/popper.vue';
 import { Screen } from '../../../../_common/screen/screen-service';
 import { AppThemeSvg } from '../../../../_common/theme/svg/svg';
 import { AppTooltip } from '../../../../_common/tooltip/tooltip';
-import Vue from 'vue';
-import { Component } from 'vue-property-decorator';
-import { Action, State } from 'vuex-class';
 import { Store } from '../../../store/index';
 import { ChatClient } from '../../chat/client';
 import AppSearch from '../../search/search.vue';
@@ -33,6 +34,7 @@ if (GJ_IS_CLIENT) {
 	directives: {
 		AppTooltip,
 		AppTrackEvent,
+		AppObserveDimensions,
 	},
 })
 export default class AppShellTopNav extends Vue {
@@ -64,8 +66,49 @@ export default class AppShellTopNav extends Vue {
 	unreadActivityCount!: Store['unreadActivityCount'];
 
 	moreMenuShowing = false;
+	baseMinColWidth: number | null = null;
+
+	$refs!: {
+		left: HTMLDivElement;
+		right: HTMLDivElement;
+	};
 
 	readonly Environment = Environment;
 	readonly Screen = Screen;
 	readonly Connection = Connection;
+
+	get minColWidth() {
+		// When we are smaller than this, we just set the search to stretch
+		// full-width with a max-width. It mostly looks fine on sizes smaller
+		// than this.
+		if (Screen.width < 1300) {
+			return null;
+		}
+
+		return this.baseMinColWidth && this.baseMinColWidth + 'px';
+	}
+
+	// Every time either the left or right column's dimensions changes, we run
+	// this function.
+	checkColWidths() {
+		const left = (this.$refs.left && this.$refs.left.getBoundingClientRect().width) || 0;
+		const right = (this.$refs.right && this.$refs.right.getBoundingClientRect().width) || 0;
+
+		// We want to size both columns to be the same width, so choose the
+		// largest among them.
+		let max = Math.max(left, right);
+		if (!max) {
+			this.baseMinColWidth = null;
+			return;
+		}
+
+		// Page content is centered within a column that is offset by the cbar,
+		// so this does the same offseting within the top nav for the search bar
+		// to align properly in the center with the page content.
+		if (this.hasCbar) {
+			max -= 70;
+		}
+
+		this.baseMinColWidth = max;
+	}
 }

--- a/src/app/components/shell/top-nav/top-nav.vue
+++ b/src/app/components/shell/top-nav/top-nav.vue
@@ -1,161 +1,174 @@
 <template>
 	<nav id="shell-top-nav" class="navbar">
-		<div class="navbar-left">
-			<a
-				v-if="hasSidebar"
-				class="navbar-item"
-				:class="{
-					'-menu-toggle': hasCbar,
-					active: isLeftPaneVisible,
-				}"
-				@click="toggleLeftPane"
-				v-app-tooltip.right="$gettext(`Playlists (m)`)"
-				v-app-track-event="`top-nav:main-menu:toggle`"
-			>
-				<app-jolticon icon="menu" />
-			</a>
-
-			<!-- History Navigator (for desktop client) -->
-			<app-client-history-navigator v-if="GJ_IS_CLIENT" />
-
-			<router-link
-				class="navbar-item"
-				:class="{ active: $route.name === 'home' }"
-				:to="{ name: 'home' }"
-				v-app-track-event="`top-nav:main-menu:home`"
-			>
-				<app-theme-svg v-if="!Screen.isMobile" src="~img/game-jolt-logo.svg" alt="" />
-				<app-theme-svg v-else src="~img/jolt.svg" alt="" />
-				<span
-					class="notification-tag tag tag-highlight anim-fade-enter anim-fade-leave"
-					v-if="unreadActivityCount > 0"
+		<div ref="left" class="navbar-left" :style="{ 'min-width': minColWidth }">
+			<div class="-col" v-app-observe-dimensions="checkColWidths">
+				<a
+					v-if="hasSidebar"
+					class="navbar-item"
+					:class="{
+						'-menu-toggle': hasCbar,
+						active: isLeftPaneVisible,
+					}"
+					@click="toggleLeftPane"
+					v-app-tooltip.right="$gettext(`Playlists (m)`)"
+					v-app-track-event="`top-nav:main-menu:toggle`"
 				>
-					{{ unreadActivityCount < 100 ? unreadActivityCount : '99+' }}
-				</span>
-			</router-link>
-
-			<router-link
-				v-if="!Screen.isXs && app.user"
-				class="-explore navbar-item"
-				:class="{ active: $route.name === 'discover.home' }"
-				:to="{ name: 'discover.home' }"
-				v-app-track-event="`top-nav:main-menu:discover`"
-			>
-				<app-jolticon icon="compass-needle" class="-explore-icon" />
-				<strong class="text-upper">
-					<translate>Explore</translate>
-				</strong>
-			</router-link>
-
-			<app-popper
-				v-if="!Screen.isXs"
-				hide-on-state-change
-				@show="moreMenuShowing = true"
-				@hide="moreMenuShowing = false"
-				v-app-track-event="`top-nav:more-menu:toggle`"
-			>
-				<a class="navbar-item" :class="{ active: moreMenuShowing }">
-					<app-jolticon icon="ellipsis-v" />
+					<app-jolticon icon="menu" />
 				</a>
 
-				<div class="fill-darkest" slot="popover">
-					<div class="list-group-dark">
-						<router-link
-							class="list-group-item has-icon offline-disable"
-							v-if="!GJ_IS_CLIENT && !Screen.isXs"
-							:to="{ name: 'landing.client' }"
-							v-app-track-event="`sidebar:client`"
-						>
-							<app-jolticon icon="client" />
-							<translate>Client</translate>
-						</router-link>
-						<router-link
-							class="list-group-item has-icon offline-disable"
-							:to="{ name: 'forums.landing.overview' }"
-							v-app-track-event="`sidebar:forums`"
-						>
-							<app-jolticon icon="forums" />
-							<translate>Forums</translate>
-						</router-link>
-						<a
-							class="list-group-item has-icon offline-disable"
-							:href="Environment.jamsBaseUrl"
-							target="_blank"
-							v-app-track-event="`sidebar:jams`"
-						>
-							<app-jolticon icon="jams" />
-							<translate>Jams</translate>
-						</a>
-					</div>
-				</div>
-			</app-popper>
+				<!-- History Navigator (for desktop client) -->
+				<app-client-history-navigator v-if="GJ_IS_CLIENT" />
 
-			<span class="navbar-separator hidden-xs" />
+				<router-link
+					class="navbar-item"
+					:class="{ active: $route.name === 'home' }"
+					:to="{ name: 'home' }"
+					v-app-track-event="`top-nav:main-menu:home`"
+				>
+					<app-theme-svg v-if="!Screen.isMobile" src="~img/game-jolt-logo.svg" alt="" />
+					<app-theme-svg v-else src="~img/jolt.svg" alt="" />
+					<span
+						class="notification-tag tag tag-highlight anim-fade-enter anim-fade-leave"
+						v-if="unreadActivityCount > 0"
+					>
+						{{ unreadActivityCount < 100 ? unreadActivityCount : '99+' }}
+					</span>
+				</router-link>
+
+				<router-link
+					v-if="!Screen.isXs && app.user"
+					class="-explore navbar-item"
+					:class="{ active: $route.name === 'discover.home' }"
+					:to="{ name: 'discover.home' }"
+					v-app-track-event="`top-nav:main-menu:discover`"
+				>
+					<app-jolticon icon="compass-needle" class="-explore-icon" />
+					<strong class="text-upper">
+						<translate>Explore</translate>
+					</strong>
+				</router-link>
+
+				<app-popper
+					v-if="!Screen.isXs"
+					hide-on-state-change
+					@show="moreMenuShowing = true"
+					@hide="moreMenuShowing = false"
+					v-app-track-event="`top-nav:more-menu:toggle`"
+				>
+					<a class="navbar-item" :class="{ active: moreMenuShowing }">
+						<app-jolticon icon="ellipsis-v" />
+					</a>
+
+					<div class="fill-darkest" slot="popover">
+						<div class="list-group-dark">
+							<router-link
+								class="list-group-item has-icon offline-disable"
+								v-if="!GJ_IS_CLIENT && !Screen.isXs"
+								:to="{ name: 'landing.client' }"
+								v-app-track-event="`sidebar:client`"
+							>
+								<app-jolticon icon="client" />
+								<translate>Client</translate>
+							</router-link>
+							<router-link
+								class="list-group-item has-icon offline-disable"
+								:to="{ name: 'forums.landing.overview' }"
+								v-app-track-event="`sidebar:forums`"
+							>
+								<app-jolticon icon="forums" />
+								<translate>Forums</translate>
+							</router-link>
+							<a
+								class="list-group-item has-icon offline-disable"
+								:href="Environment.jamsBaseUrl"
+								target="_blank"
+								v-app-track-event="`sidebar:jams`"
+							>
+								<app-jolticon icon="jams" />
+								<translate>Jams</translate>
+							</a>
+						</div>
+					</div>
+				</app-popper>
+			</div>
 		</div>
 
 		<div class="navbar-center">
-			<!-- Search Input -->
-			<app-search v-if="!Screen.isXs"></app-search>
+			<div class="-search">
+				<!-- Search Input -->
+				<app-search v-if="!Screen.isXs"></app-search>
+			</div>
 		</div>
 
 		<!--
-			Cloak this so that it doesn't flash wrong things before we load the user.
-			Fixes: https://github.com/gamejolt/issue-tracker/issues/382
+			Hide this until we load the user data in, otherwise it'll flash
+			login/join buttons.
+			https://github.com/gamejolt/issue-tracker/issues/382
 		-->
-		<div class="navbar-right" v-if="app.userBootstrapped">
-			<template v-if="app.user">
-				<!-- Notifications -->
-				<app-shell-notification-popover />
+		<div
+			ref="right"
+			v-if="app.userBootstrapped"
+			class="navbar-right"
+			:style="{ 'min-width': minColWidth }"
+		>
+			<div class="-col" v-app-observe-dimensions="checkColWidths">
+				<template v-if="app.user">
+					<!-- Notifications -->
+					<app-shell-notification-popover />
 
-				<!-- Friend Requests -->
-				<app-shell-friend-request-popover />
+					<!-- Friend Requests -->
+					<app-shell-friend-request-popover />
 
-				<!-- Chat -->
-				<a
-					v-if="chat"
-					class="navbar-item"
-					:class="{ active: isRightPaneVisible }"
-					@click="toggleRightPane"
-					v-app-tooltip.left="$gettext(`Chat and Friends List (c)`)"
-					v-app-track-event="`top-nav:chat:toggle`"
-				>
-					<span
-						class="notification-tag tag tag-highlight anim-fade-enter anim-fade-leave"
-						v-if="chat.friendNotificationsCount"
+					<!-- Chat -->
+					<a
+						v-if="chat"
+						class="navbar-item"
+						:class="{ active: isRightPaneVisible }"
+						@click="toggleRightPane"
+						v-app-tooltip.left="$gettext(`Chat and Friends List (c)`)"
+						v-app-track-event="`top-nav:chat:toggle`"
 					>
-						{{ chat.friendNotificationsCount }}
+						<span
+							class="notification-tag tag tag-highlight anim-fade-enter anim-fade-leave"
+							v-if="chat.friendNotificationsCount"
+						>
+							{{ chat.friendNotificationsCount }}
+						</span>
+						<app-jolticon icon="user-messages" />
+					</a>
+
+					<!-- Connection Status -->
+					<span
+						v-if="Connection.isOffline"
+						class="navbar-item disconnected-icon"
+						v-app-tooltip.left="$gettext(`We're having trouble connecting to Game Jolt.`)"
+					>
+						<app-jolticon icon="offline" />
 					</span>
-					<app-jolticon icon="user-messages" />
-				</a>
 
-				<!-- Connection Status -->
-				<span
-					v-if="Connection.isOffline"
-					class="navbar-item disconnected-icon"
-					v-app-tooltip.left="$gettext(`We're having trouble connecting to Game Jolt.`)"
-				>
-					<app-jolticon icon="offline" />
-				</span>
+					<!-- User Menu -->
+					<app-shell-account-popover />
+				</template>
 
-				<!-- User Menu -->
-				<app-shell-account-popover />
-			</template>
-
-			<!-- Login/Join Buttons -->
-			<template v-if="!app.user">
-				<ul class="navbar-items">
-					<li>
-						<a :href="Environment.authBaseUrl + '/login'" v-app-track-event="`top-nav:login:click`">
-							<translate>nav.login</translate>
-						</a>
-					</li>
-					<li>
-						<a :href="Environment.authBaseUrl + '/join'" v-app-track-event="`top-nav:join:click`">
-							<translate>Sign Up</translate>
-						</a>
-					</li>
-				</ul>
-			</template>
+				<!-- Login/Join Buttons -->
+				<template v-if="!app.user">
+					<ul class="navbar-items">
+						<li>
+							<a
+								:href="Environment.authBaseUrl + '/login'"
+								v-app-track-event="`top-nav:login:click`"
+							>
+								<translate>nav.login</translate>
+							</a>
+						</li>
+						<li>
+							<a :href="Environment.authBaseUrl + '/join'" v-app-track-event="`top-nav:join:click`">
+								<translate>Sign Up</translate>
+							</a>
+						</li>
+					</ul>
+				</template>
+			</div>
 		</div>
 	</nav>
 </template>
@@ -183,6 +196,20 @@
 .-explore-icon
 	position: relative
 	top: 2px
+
+// Centered with some spacing around it so it never bunches up too close to the
+// navbar columns.
+.-search
+	margin: 0 auto
+	padding-left: 24px
+	padding-right: 24px
+	max-width: 600px
+
+.navbar-left, .navbar-right
+	display: flex
+
+.navbar-right
+	justify-content: flex-end
 </style>
 
 <script lang="ts" src="./top-nav"></script>

--- a/src/app/views/search/search.vue
+++ b/src/app/views/search/search.vue
@@ -2,6 +2,9 @@
 	<div>
 		<app-page-header should-affix-nav :hide-nav="!hasSearch">
 			<template v-if="Screen.isXs">
+				<label>
+					<translate>Enter your search</translate>
+				</label>
 				<!--
 					If they click into a tag (which goes to search page), we
 					don't want to autofocus the input since they're trying to


### PR DESCRIPTION
- Make it stand out more by putting it in a lighter background than the top bar bg.
- New directive! AppObserveDimensions, can be used to make a ResizeObserver really easily.
- Search bar is responsive to the navbar-start/end column widths and keeps itself centered against the page below. This was kind of tricky, but I added comments.

New:
![Screenshot from 2019-12-23 17-46-04](https://user-images.githubusercontent.com/1024321/71388236-580bea80-25ac-11ea-8235-3fcdf93b0cdb.png)

Old:
![Screenshot from 2019-12-23 17-45-41](https://user-images.githubusercontent.com/1024321/71388232-517d7300-25ac-11ea-8c41-44ddd1fa303b.png)