### PR TITLE
Made app-track-event a common directive that's included by default.

### DIFF
--- a/src/_common/audio/playlist/playlist.ts
+++ b/src/_common/audio/playlist/playlist.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Emit, Prop } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../analytics/track-event.directive';
 import { time } from '../../filters/time';
 import { GameSong } from '../../game/song/song.model';
 import { AppAudioPlayer } from '../player/player';
@@ -10,9 +9,6 @@ import AppAudioScrubber from '../scrubber/scrubber.vue';
 	components: {
 		AppAudioPlayer,
 		AppAudioScrubber,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 	filters: {
 		time,

--- a/src/_common/bootstrap.ts
+++ b/src/_common/bootstrap.ts
@@ -4,6 +4,7 @@ import { hijackLinks } from '../utils/router';
 import { bootstrapAppTranslations } from '../utils/translations';
 import { VuexStore } from '../utils/vuex';
 import { Analytics } from './analytics/analytics.service';
+import { AppTrackEvent } from './analytics/track-event.directive';
 import AppButton from './button/button.vue';
 import { Connection } from './connection/connection-service';
 import AppJolticon from './jolticon/jolticon.vue';
@@ -38,6 +39,7 @@ export function bootstrapCommon(appComponent: typeof Vue, store: VuexStore, rout
 	Vue.component('AppJolticon', AppJolticon);
 	Vue.component('AppLinkExternal', AppLinkExternal);
 	Vue.component('AppLinkHelp', AppLinkHelp);
+	Vue.directive('AppTrackEvent', AppTrackEvent);
 
 	// Set some constants so we can use them in templates.
 	Vue.use(vue => {

--- a/src/_common/comment/content/content.ts
+++ b/src/_common/comment/content/content.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../analytics/track-event.directive';
 import AppContentViewer from '../../content/content-viewer/content-viewer.vue';
 import AppFadeCollapse from '../../fade-collapse/fade-collapse.vue';
 import { date } from '../../filters/date';
@@ -13,9 +12,6 @@ import AppCommentVideoThumbnail from '../video/thumbnail/thumbnail.vue';
 		AppFadeCollapse,
 		AppCommentVideoThumbnail,
 		AppContentViewer,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 	filters: {
 		date,

--- a/src/_common/comment/controls/controls.ts
+++ b/src/_common/comment/controls/controls.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../analytics/track-event.directive';
 import { AppAuthRequired } from '../../auth/auth-required-directive';
 import { number } from '../../filters/number';
 import { LikersModal } from '../../likers/modal.service';
@@ -13,7 +12,6 @@ import { CommentVote } from '../vote/vote-model';
 	directives: {
 		AppAuthRequired,
 		AppTooltip,
-		AppTrackEvent,
 	},
 	filters: {
 		number,

--- a/src/_common/comment/video/modal/modal.ts
+++ b/src/_common/comment/video/modal/modal.ts
@@ -1,6 +1,5 @@
 import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../analytics/track-event.directive';
 import AppContentViewer from '../../../content/content-viewer/content-viewer.vue';
 import { number } from '../../../filters/number';
 import AppGameThumbnail from '../../../game/thumbnail/thumbnail.vue';
@@ -26,9 +25,6 @@ import { CommentVideo } from '../video-model';
 		AppUserFollowWidget,
 		AppCommentVideoLikeWidget,
 		AppContentViewer,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 	filters: {
 		number,

--- a/src/_common/comment/video/thumbnail/thumbnail.ts
+++ b/src/_common/comment/video/thumbnail/thumbnail.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../analytics/track-event.directive';
 import { AppStore } from '../../../store/app-store';
 import { AppTooltip } from '../../../tooltip/tooltip';
 import AppUserCardHover from '../../../user/card/hover/hover.vue';
@@ -16,7 +15,6 @@ import './thumbnail-content.styl';
 		AppUserAvatar,
 	},
 	directives: {
-		AppTrackEvent,
 		AppTooltip,
 	},
 })

--- a/src/_common/comment/widget/comment/comment.ts
+++ b/src/_common/comment/widget/comment/comment.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { findRequiredVueParent } from '../../../../utils/vue';
-import { AppTrackEvent } from '../../../analytics/track-event.directive';
 import { AppAuthRequired } from '../../../auth/auth-required-directive';
 import { Clipboard } from '../../../clipboard/clipboard-service';
 import { Collaborator } from '../../../collaborator/collaborator.model';
@@ -44,7 +43,6 @@ let CommentNum = 0;
 		AppCommentWidgetComment: () => Promise.resolve(AppCommentWidgetComment),
 	},
 	directives: {
-		AppTrackEvent,
 		AppTooltip,
 		AppAuthRequired,
 	},

--- a/src/_common/comment/widget/widget.ts
+++ b/src/_common/comment/widget/widget.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { Analytics } from '../../analytics/analytics.service';
-import { AppTrackEvent } from '../../analytics/track-event.directive';
 import { AppAuthRequired } from '../../auth/auth-required-directive';
 import { Collaborator } from '../../collaborator/collaborator.model';
 import { Environment } from '../../environment/environment.service';
@@ -42,7 +41,6 @@ let incrementer = 0;
 	},
 	directives: {
 		AppAuthRequired,
-		AppTrackEvent,
 	},
 })
 export default class AppCommentWidget extends Vue {

--- a/src/_common/community/join-widget/join-widget.ts
+++ b/src/_common/community/join-widget/join-widget.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Component, Emit, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { GridClient } from '../../../app/components/grid/client.service';
-import { AppTrackEvent } from '../../analytics/track-event.directive';
 import { AppAuthRequired } from '../../auth/auth-required-directive';
 import { number } from '../../filters/number';
 import { Growls } from '../../growls/growls.service';
@@ -14,7 +13,6 @@ import { $joinCommunity, $leaveCommunity, Community } from '../community.model';
 @Component({
 	directives: {
 		AppAuthRequired,
-		AppTrackEvent,
 		AppTooltip,
 	},
 })

--- a/src/_common/game/external-package/card/card.ts
+++ b/src/_common/game/external-package/card/card.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { Analytics } from '../../../analytics/analytics.service';
-import { AppTrackEvent } from '../../../analytics/track-event.directive';
 import AppCard from '../../../card/card.vue';
 import AppFadeCollapse from '../../../fade-collapse/fade-collapse.vue';
 import { Navigate } from '../../../navigate/navigate.service';
@@ -16,7 +15,6 @@ import { GameExternalPackage } from '../external-package.model';
 	},
 	directives: {
 		AppTooltip,
-		AppTrackEvent,
 	},
 })
 export default class AppGameExternalPackageCard extends Vue {

--- a/src/_common/game/package/card/buttons.ts
+++ b/src/_common/game/package/card/buttons.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../analytics/track-event.directive';
 import { filesize } from '../../../filters/filesize';
 import AppPopper from '../../../popper/popper.vue';
 import { Screen } from '../../../screen/screen-service';
@@ -13,9 +12,6 @@ import AppGamePackageCardMoreOptions from './more-options.vue';
 	components: {
 		AppPopper,
 		AppGamePackageCardMoreOptions,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 	filters: {
 		filesize,

--- a/src/_common/game/package/card/card.ts
+++ b/src/_common/game/package/card/card.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { Analytics } from '../../../analytics/analytics.service';
-import { AppTrackEvent } from '../../../analytics/track-event.directive';
 import AppCard from '../../../card/card.vue';
 import { Clipboard } from '../../../clipboard/clipboard-service';
 import { AppCountdown } from '../../../countdown/countdown';
@@ -36,7 +35,6 @@ import { GamePackageCardModel } from './card.model';
 	},
 	directives: {
 		AppTooltip,
-		AppTrackEvent,
 	},
 	filters: {
 		currency,

--- a/src/_common/game/package/card/more-options.ts
+++ b/src/_common/game/package/card/more-options.ts
@@ -1,14 +1,10 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../analytics/track-event.directive';
 import { filesize } from '../../../filters/filesize';
 import { GameBuild } from '../../build/build.model';
 import { GamePackageCardModel } from './card.model';
 
 @Component({
-	directives: {
-		AppTrackEvent,
-	},
 	filters: {
 		filesize,
 	},

--- a/src/_common/game/soundtrack/card/card.ts
+++ b/src/_common/game/soundtrack/card/card.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../analytics/track-event.directive';
 import AppAudioPlaylistTS from '../../../audio/playlist/playlist';
 import AppAudioPlaylist from '../../../audio/playlist/playlist.vue';
 import AppCard from '../../../card/card.vue';
@@ -17,9 +16,6 @@ import { GameSong } from '../../song/song.model';
 		AppCard,
 		AppFadeCollapse,
 		AppAudioPlaylist,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppGameSoundtrackCard extends Vue {

--- a/src/_common/user/follow/widget.ts
+++ b/src/_common/user/follow/widget.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Component, Emit, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { Analytics } from '../../analytics/analytics.service';
-import { AppTrackEvent } from '../../analytics/track-event.directive';
 import { AppAuthRequired } from '../../auth/auth-required-directive';
 import { number } from '../../filters/number';
 import { Growls } from '../../growls/growls.service';
@@ -14,7 +13,6 @@ import { User } from '../user.model';
 @Component({
 	directives: {
 		AppAuthRequired,
-		AppTrackEvent,
 		AppTooltip,
 	},
 })

--- a/src/app/components/activity/feed/feed.ts
+++ b/src/app/components/activity/feed/feed.ts
@@ -3,7 +3,6 @@ import Vue from 'vue';
 import { Component, Emit, Prop, Provide, Watch } from 'vue-property-decorator';
 import { Ads } from '../../../../_common/ad/ads.service';
 import AppAdWidget from '../../../../_common/ad/widget/widget.vue';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { CommunityChannel } from '../../../../_common/community/channel/channel.model';
 import { Community } from '../../../../_common/community/community.model';
 import { EventItem } from '../../../../_common/event-item/event-item.model';
@@ -26,9 +25,6 @@ import { ActivityFeedView } from './view';
 		AppAdWidget,
 		AppExpand,
 		AppScrollInview,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppActivityFeed extends Vue {

--- a/src/app/components/broadcast-card/broadcast-card.ts
+++ b/src/app/components/broadcast-card/broadcast-card.ts
@@ -1,15 +1,11 @@
-import { AppTrackEvent } from '../../../_common/analytics/track-event.directive';
-import AppCard from '../../../_common/card/card.vue';
-import { FiresidePost } from '../../../_common/fireside/post/post-model';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+import AppCard from '../../../_common/card/card.vue';
+import { FiresidePost } from '../../../_common/fireside/post/post-model';
 
 @Component({
 	components: {
 		AppCard,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppBroadcastCard extends Vue {

--- a/src/app/components/client/hooks/package-card-buttons/package-card-buttons.ts
+++ b/src/app/components/client/hooks/package-card-buttons/package-card-buttons.ts
@@ -1,8 +1,11 @@
 import * as fs from 'fs';
+import * as path from 'path';
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
 import { Analytics } from '../../../../../_common/analytics/analytics.service';
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import { Device } from '../../../../../_common/device/device.service';
 import AppExpand from '../../../../../_common/expand/expand.vue';
+import { filesize } from '../../../../../_common/filters/filesize';
 import { GameBuild } from '../../../../../_common/game/build/build.model';
 import { Game } from '../../../../../_common/game/game.model';
 import { GamePackageCardModel } from '../../../../../_common/game/package/card/card.model';
@@ -11,10 +14,6 @@ import { GamePackage } from '../../../../../_common/game/package/package.model';
 import { Popper } from '../../../../../_common/popper/popper.service';
 import AppPopper from '../../../../../_common/popper/popper.vue';
 import { AppTooltip } from '../../../../../_common/tooltip/tooltip';
-import { filesize } from '../../../../../_common/filters/filesize';
-import * as path from 'path';
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
 import {
 	ClientLibraryAction,
 	ClientLibraryState,
@@ -36,7 +35,6 @@ import {
 	},
 	directives: {
 		AppTooltip,
-		AppTrackEvent,
 	},
 	filters: {
 		filesize,

--- a/src/app/components/client/install-package-modal/install-package-modal.ts
+++ b/src/app/components/client/install-package-modal/install-package-modal.ts
@@ -1,6 +1,5 @@
 import { Component, Prop } from 'vue-property-decorator';
 import { arrayIndexBy } from '../../../../utils/array';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { Api } from '../../../../_common/api/api.service';
 import { Device } from '../../../../_common/device/device.service';
 import { filesize } from '../../../../_common/filters/filesize';
@@ -16,9 +15,6 @@ import { ClientLibraryAction, ClientLibraryStore } from '../../../store/client-l
 	components: {
 		AppLoading,
 		AppGamePackageCard,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 	filters: {
 		filesize,

--- a/src/app/components/community/slider/item/item.ts
+++ b/src/app/components/community/slider/item/item.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import { Community } from '../../../../../_common/community/community.model';
 import AppCommunityThumbnailImg from '../../../../../_common/community/thumbnail/img/img.vue';
 import { Store } from '../../../../store/index';
@@ -9,9 +8,6 @@ import { Store } from '../../../../store/index';
 @Component({
 	components: {
 		AppCommunityThumbnailImg,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppCommunitySliderItem extends Vue {

--- a/src/app/components/follower/list/list.ts
+++ b/src/app/components/follower/list/list.ts
@@ -1,21 +1,17 @@
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
+import Vue from 'vue';
+import { Component, Prop, Watch } from 'vue-property-decorator';
 import { Api } from '../../../../_common/api/api.service';
+import AppLoading from '../../../../_common/loading/loading.vue';
 import { Screen } from '../../../../_common/screen/screen-service';
 import AppUserCard from '../../../../_common/user/card/card.vue';
 import AppUserCardPlaceholder from '../../../../_common/user/card/placeholder/placeholder.vue';
 import { User } from '../../../../_common/user/user.model';
-import AppLoading from '../../../../_common/loading/loading.vue';
-import Vue from 'vue';
-import { Component, Prop, Watch } from 'vue-property-decorator';
 
 @Component({
 	components: {
 		AppUserCard,
 		AppUserCardPlaceholder,
 		AppLoading,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppFollowerList extends Vue {

--- a/src/app/components/forum/topic/upvote-widget/upvote-widget.ts
+++ b/src/app/components/forum/topic/upvote-widget/upvote-widget.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import { AppAuthRequired } from '../../../../../_common/auth/auth-required-directive';
 import { number } from '../../../../../_common/filters/number';
 import { ForumTopic } from '../../../../../_common/forum/topic/topic.model';
@@ -10,7 +9,6 @@ import { AppTooltip } from '../../../../../_common/tooltip/tooltip';
 	directives: {
 		AppAuthRequired,
 		AppTooltip,
-		AppTrackEvent,
 	},
 	filters: {
 		number,

--- a/src/app/components/game-playlist/add-to-widget/add-to-widget.ts
+++ b/src/app/components/game-playlist/add-to-widget/add-to-widget.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { AppAuthRequired } from '../../../../_common/auth/auth-required-directive';
 import { Game } from '../../../../_common/game/game.model';
 import AppPopper from '../../../../_common/popper/popper.vue';
@@ -16,7 +15,6 @@ import AppGamePlaylistAddToPopover from '../add-to-popover/add-to-popover.vue';
 	},
 	directives: {
 		AppAuthRequired,
-		AppTrackEvent,
 		AppTooltip,
 	},
 })

--- a/src/app/components/game/collection/follow-widget/follow-widget.ts
+++ b/src/app/components/game/collection/follow-widget/follow-widget.ts
@@ -1,16 +1,14 @@
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
-import { AppAuthRequired } from '../../../../../_common/auth/auth-required-directive';
-import { AppTooltip } from '../../../../../_common/tooltip/tooltip';
-import { number } from '../../../../../_common/filters/number';
-import { AppState, AppStore } from '../../../../../_common/store/app-store';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+import { AppAuthRequired } from '../../../../../_common/auth/auth-required-directive';
+import { number } from '../../../../../_common/filters/number';
+import { AppState, AppStore } from '../../../../../_common/store/app-store';
+import { AppTooltip } from '../../../../../_common/tooltip/tooltip';
 import { LibraryModule, LibraryStore } from '../../../../store/library';
 import { GameCollection } from '../collection.model';
 
 @Component({
 	directives: {
-		AppTrackEvent,
 		AppTooltip,
 		AppAuthRequired,
 	},
@@ -50,13 +48,16 @@ export default class AppGameCollectionFollowWidget extends Vue {
 
 		return (
 			this.collections.findIndex(
-				item => item.type === this.collection.type && (item as any).id === this.collection.id
+				item =>
+					item.type === this.collection.type && (item as any).id === this.collection.id
 			) !== -1
 		);
 	}
 
 	get badge() {
-		return !this.circle && this.isFollowing && this.followerCount ? number(this.followerCount) : '';
+		return !this.circle && this.isFollowing && this.followerCount
+			? number(this.followerCount)
+			: '';
 	}
 
 	get tooltip() {

--- a/src/app/components/game/collection/grid/item/item.ts
+++ b/src/app/components/game/collection/grid/item/item.ts
@@ -1,4 +1,3 @@
-import { AppTrackEvent } from '../../../../../../_common/analytics/track-event.directive';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
@@ -9,9 +8,6 @@ import AppGameCollectionThumbnail from '../../thumbnail/thumbnail.vue';
 @Component({
 	components: {
 		AppGameCollectionThumbnail,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppGameCollectionGridItem extends Vue {

--- a/src/app/components/game/collection/list/list.ts
+++ b/src/app/components/game/collection/list/list.ts
@@ -1,4 +1,3 @@
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
@@ -9,9 +8,6 @@ import AppGameCollectionThumbnail from '../thumbnail/thumbnail.vue';
 @Component({
 	components: {
 		AppGameCollectionThumbnail,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppGameCollectionList extends Vue {

--- a/src/app/components/game/filtering/widget.ts
+++ b/src/app/components/game/filtering/widget.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { Analytics } from '../../../../_common/analytics/analytics.service';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { number } from '../../../../_common/filters/number';
 import AppPopper from '../../../../_common/popper/popper.vue';
 import { Store } from '../../../store/index';
@@ -11,9 +10,6 @@ import { GameFilteringContainer } from './container';
 @Component({
 	components: {
 		AppPopper,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 	filters: {
 		number,

--- a/src/app/components/game/follow-widget/follow-widget.ts
+++ b/src/app/components/game/follow-widget/follow-widget.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { AppAuthRequired } from '../../../../_common/auth/auth-required-directive';
 import { number } from '../../../../_common/filters/number';
 import { Game } from '../../../../_common/game/game.model';
@@ -19,7 +18,6 @@ import { Store } from '../../../store/index';
 	},
 	directives: {
 		AppAuthRequired,
-		AppTrackEvent,
 		AppTooltip,
 	},
 })

--- a/src/app/components/game/grid/grid.ts
+++ b/src/app/components/game/grid/grid.ts
@@ -1,13 +1,12 @@
-import { Ads } from '../../../../_common/ad/ads.service';
-import AppAdWidget from '../../../../_common/ad/widget/widget.vue';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
-import { AppCondenseWhitespace } from '../../../../_common/condense-whitespace';
-import { Game } from '../../../../_common/game/game.model';
-import { Screen } from '../../../../_common/screen/screen-service';
-import { number } from '../../../../_common/filters/number';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+import { Ads } from '../../../../_common/ad/ads.service';
+import AppAdWidget from '../../../../_common/ad/widget/widget.vue';
+import { AppCondenseWhitespace } from '../../../../_common/condense-whitespace';
+import { number } from '../../../../_common/filters/number';
+import { Game } from '../../../../_common/game/game.model';
 import AppGameThumbnail from '../../../../_common/game/thumbnail/thumbnail.vue';
+import { Screen } from '../../../../_common/screen/screen-service';
 
 export const GameGridRowSizeSm = 2;
 export const GameGridRowSizeMd = 3;
@@ -20,9 +19,6 @@ let idCounter = 0;
 		AppGameThumbnail,
 		AppAdWidget,
 		AppCondenseWhitespace,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppGameGrid extends Vue {

--- a/src/app/components/game/list/item/item.ts
+++ b/src/app/components/game/list/item/item.ts
@@ -1,20 +1,16 @@
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { number } from '../../../../../_common/filters/number';
 import { Game } from '../../../../../_common/game/game.model';
 import AppGameThumbnailImg from '../../../../../_common/game/thumbnail-img/thumbnail-img.vue';
 import AppUserCardHover from '../../../../../_common/user/card/hover/hover.vue';
 import AppUserVerifiedTick from '../../../../../_common/user/verified-tick/verified-tick.vue';
-import { number } from '../../../../../_common/filters/number';
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
 
 @Component({
 	components: {
 		AppGameThumbnailImg,
 		AppUserCardHover,
 		AppUserVerifiedTick,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppGameListItem extends Vue {

--- a/src/app/components/game/listing/listing.ts
+++ b/src/app/components/game/listing/listing.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { Environment } from '../../../../_common/environment/environment.service';
 import { number } from '../../../../_common/filters/number';
 import AppLoadingFade from '../../../../_common/loading/fade/fade.vue';
@@ -21,9 +20,6 @@ import { GameListingContainer } from './listing-container-service';
 		AppGameFilteringTags,
 		AppGameGridPlaceholder,
 		AppNavTabList,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppGameListing extends Vue {

--- a/src/app/components/search/autocomplete/autocomplete.ts
+++ b/src/app/components/search/autocomplete/autocomplete.ts
@@ -1,16 +1,15 @@
-import { Analytics } from '../../../../_common/analytics/analytics.service';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
-import { Game } from '../../../../_common/game/game.model';
-import AppGameThumbnailImg from '../../../../_common/game/thumbnail-img/thumbnail-img.vue';
-import { User } from '../../../../_common/user/user.model';
-import AppUserVerifiedTick from '../../../../_common/user/verified-tick/verified-tick.vue';
-import { findRequiredVueParent } from '../../../../utils/vue';
-import { AppStore } from '../../../../_common/store/app-store';
 import 'rxjs/add/operator/debounceTime';
 import { Subject } from 'rxjs/Subject';
 import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 import { State } from 'vuex-class';
+import { findRequiredVueParent } from '../../../../utils/vue';
+import { Analytics } from '../../../../_common/analytics/analytics.service';
+import { Game } from '../../../../_common/game/game.model';
+import AppGameThumbnailImg from '../../../../_common/game/thumbnail-img/thumbnail-img.vue';
+import { AppStore } from '../../../../_common/store/app-store';
+import { User } from '../../../../_common/user/user.model';
+import AppUserVerifiedTick from '../../../../_common/user/verified-tick/verified-tick.vue';
 import * as _LocalDbGameMod from '../../client/local-db/game/game.model';
 import AppGameCompatIcons from '../../game/compat-icons/compat-icons.vue';
 import AppSearchTS from '../search';
@@ -31,9 +30,6 @@ const KEYCODE_ENTER = 13;
 		AppGameThumbnailImg,
 		AppGameCompatIcons,
 		AppUserVerifiedTick,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppSearchAutocomplete extends Vue {

--- a/src/app/components/shell/account-popover/account-popover.ts
+++ b/src/app/components/shell/account-popover/account-popover.ts
@@ -1,18 +1,17 @@
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
-import { Api } from '../../../../_common/api/api.service';
-import { Connection } from '../../../../_common/connection/connection-service';
-import AppPopper from '../../../../_common/popper/popper.vue';
-import { Screen } from '../../../../_common/screen/screen-service';
-import { ThemeMutation, ThemeState, ThemeStore } from '../../../../_common/theme/theme.store';
-import { AppTooltip } from '../../../../_common/tooltip/tooltip';
-import AppUserAvatarImg from '../../../../_common/user/user-avatar/img/img.vue';
-import { currency } from '../../../../_common/filters/currency';
-import { AppStore } from '../../../../_common/store/app-store';
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Action, State } from 'vuex-class';
+import { Api } from '../../../../_common/api/api.service';
 import * as _ClientMod from '../../../../_common/client/client.service';
+import { Connection } from '../../../../_common/connection/connection-service';
+import { currency } from '../../../../_common/filters/currency';
+import AppPopper from '../../../../_common/popper/popper.vue';
+import { Screen } from '../../../../_common/screen/screen-service';
 import { Settings } from '../../../../_common/settings/settings.service';
+import { AppStore } from '../../../../_common/store/app-store';
+import { ThemeMutation, ThemeState, ThemeStore } from '../../../../_common/theme/theme.store';
+import { AppTooltip } from '../../../../_common/tooltip/tooltip';
+import AppUserAvatarImg from '../../../../_common/user/user-avatar/img/img.vue';
 import { Store } from '../../../store/index';
 import { UserTokenModal } from '../../user/token-modal/token-modal.service';
 import AppShellUserBox from '../user-box/user-box.vue';
@@ -29,7 +28,6 @@ if (GJ_IS_CLIENT) {
 		AppShellUserBox,
 	},
 	directives: {
-		AppTrackEvent,
 		AppTooltip,
 	},
 	filters: {

--- a/src/app/components/shell/footer/footer.ts
+++ b/src/app/components/shell/footer/footer.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { date } from '../../../../_common/filters/date';
 import { Navigate } from '../../../../_common/navigate/navigate.service';
 import { Screen } from '../../../../_common/screen/screen-service';
@@ -17,9 +16,6 @@ if (GJ_IS_CLIENT) {
 	components: {
 		AppTranslateLangSelector,
 		AppThemeSvg,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 	filters: {
 		date,

--- a/src/app/components/shell/friend-request-popover/friend-request-popover.ts
+++ b/src/app/components/shell/friend-request-popover/friend-request-popover.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Mutation, State } from 'vuex-class/lib/bindings';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { Connection } from '../../../../_common/connection/connection-service';
 import AppLoading from '../../../../_common/loading/loading.vue';
 import AppPopper from '../../../../_common/popper/popper.vue';
@@ -22,7 +21,6 @@ type Tab = 'requests' | 'pending';
 	},
 	directives: {
 		AppTooltip,
-		AppTrackEvent,
 	},
 })
 export default class AppShellFriendRequestPopover extends Vue {

--- a/src/app/components/shell/notification-popover/notification-popover.ts
+++ b/src/app/components/shell/notification-popover/notification-popover.ts
@@ -1,14 +1,13 @@
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
+import Vue from 'vue';
+import { Component, Watch } from 'vue-property-decorator';
+import { Action, Mutation, State } from 'vuex-class';
 import { Api } from '../../../../_common/api/api.service';
 import { Connection } from '../../../../_common/connection/connection-service';
+import AppLoading from '../../../../_common/loading/loading.vue';
 import { Notification } from '../../../../_common/notification/notification-model';
 import AppPopper from '../../../../_common/popper/popper.vue';
 import { Screen } from '../../../../_common/screen/screen-service';
 import { AppTooltip } from '../../../../_common/tooltip/tooltip';
-import AppLoading from '../../../../_common/loading/loading.vue';
-import Vue from 'vue';
-import { Component, Watch } from 'vue-property-decorator';
-import { Action, Mutation, State } from 'vuex-class';
 import { Store } from '../../../store';
 import AppActivityFeed from '../../activity/feed/feed.vue';
 import { ActivityFeedView } from '../../activity/feed/view';
@@ -20,7 +19,6 @@ import { ActivityFeedView } from '../../activity/feed/view';
 		AppActivityFeed,
 	},
 	directives: {
-		AppTrackEvent,
 		AppTooltip,
 	},
 })

--- a/src/app/components/shell/sidebar/collection-list.ts
+++ b/src/app/components/shell/sidebar/collection-list.ts
@@ -1,14 +1,9 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { stringSort } from '../../../../utils/array';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { GameCollection } from '../../game/collection/collection.model';
 
-@Component({
-	directives: {
-		AppTrackEvent,
-	},
-})
+@Component({})
 export default class AppShellSidebarCollectionList extends Vue {
 	@Prop(Array) collections!: GameCollection[];
 	@Prop(String) filter!: string;

--- a/src/app/components/shell/sidebar/sidebar.ts
+++ b/src/app/components/shell/sidebar/sidebar.ts
@@ -1,15 +1,14 @@
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
-import { Environment } from '../../../../_common/environment/environment.service';
-import AppExpand from '../../../../_common/expand/expand.vue';
-import { Screen } from '../../../../_common/screen/screen-service';
-import AppScrollScroller from '../../../../_common/scroll/scroller/scroller.vue';
-import { AppTooltip } from '../../../../_common/tooltip/tooltip';
-import { stringSort } from '../../../../utils/array';
-import AppShortkey from '../../../../_common/shortkey/shortkey.vue';
-import { number } from '../../../../_common/filters/number';
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Action, State } from 'vuex-class';
+import { stringSort } from '../../../../utils/array';
+import { Environment } from '../../../../_common/environment/environment.service';
+import AppExpand from '../../../../_common/expand/expand.vue';
+import { number } from '../../../../_common/filters/number';
+import { Screen } from '../../../../_common/screen/screen-service';
+import AppScrollScroller from '../../../../_common/scroll/scroller/scroller.vue';
+import AppShortkey from '../../../../_common/shortkey/shortkey.vue';
+import { AppTooltip } from '../../../../_common/tooltip/tooltip';
 import { Store } from '../../../store/index';
 import { LibraryModule, LibraryStore } from '../../../store/library';
 import AppShellSidebarCollectionList from './collection-list.vue';
@@ -23,7 +22,6 @@ import AppShellSidebarCollectionList from './collection-list.vue';
 	},
 	directives: {
 		AppTooltip,
-		AppTrackEvent,
 	},
 	filters: {
 		number,

--- a/src/app/components/shell/top-nav/top-nav.ts
+++ b/src/app/components/shell/top-nav/top-nav.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Action, State } from 'vuex-class';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { Connection } from '../../../../_common/connection/connection-service';
 import { Environment } from '../../../../_common/environment/environment.service';
 import { AppObserveDimensions } from '../../../../_common/observe-dimensions/observe-dimensions.directive';
@@ -33,7 +32,6 @@ if (GJ_IS_CLIENT) {
 	components,
 	directives: {
 		AppTooltip,
-		AppTrackEvent,
 		AppObserveDimensions,
 	},
 })

--- a/src/app/components/tag/list/list.ts
+++ b/src/app/components/tag/list/list.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import AppScrollScroller from '../../../../_common/scroll/scroller/scroller.vue';
 import { TagInfo, TagsInfo } from '../tags-info.service';
 import AppTagThumbnail from '../thumbnail/thumbnail.vue';
@@ -34,9 +33,6 @@ const FeaturedTags = [
 	components: {
 		AppScrollScroller,
 		AppTagThumbnail,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppTagList extends Vue {

--- a/src/app/components/tag/thumbnail/thumbnail.ts
+++ b/src/app/components/tag/thumbnail/thumbnail.ts
@@ -1,14 +1,9 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { Location } from 'vue-router';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { TagsInfo } from '../tags-info.service';
 
-@Component({
-	directives: {
-		AppTrackEvent,
-	},
-})
+@Component({})
 export default class AppTagThumbnail extends Vue {
 	@Prop({ type: String, required: true })
 	tag!: string;

--- a/src/app/components/trophy/list/paged/paged.ts
+++ b/src/app/components/trophy/list/paged/paged.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import { Api } from '../../../../../_common/api/api.service';
 import AppLoading from '../../../../../_common/loading/loading.vue';
 import { Screen } from '../../../../../_common/screen/screen-service';
@@ -15,9 +14,6 @@ const PAGE_SIZE = 12;
 	components: {
 		AppTrophyCard,
 		AppLoading,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppTrophyListPaged extends Vue {

--- a/src/app/components/user/list/item/item.ts
+++ b/src/app/components/user/list/item/item.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Emit, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import { Screen } from '../../../../../_common/screen/screen-service';
 import { AppStore } from '../../../../../_common/store/app-store';
 import AppUserCardHover from '../../../../../_common/user/card/hover/hover.vue';
@@ -16,9 +15,6 @@ import AppUserVerifiedTick from '../../../../../_common/user/verified-tick/verif
 		AppUserFollowWidget,
 		AppUserVerifiedTick,
 		AppUserCardHover,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppUserListItem extends Vue {

--- a/src/app/views/discover/games/view/download/build/build.ts
+++ b/src/app/views/discover/games/view/download/build/build.ts
@@ -3,7 +3,6 @@ import { State } from 'vuex-class';
 import AppAdPlacement from '../../../../../../../_common/ad/placement/placement.vue';
 import AppAdPlaywireVideo from '../../../../../../../_common/ad/playwire/video.vue';
 import AppAdWidget from '../../../../../../../_common/ad/widget/widget.vue';
-import { AppTrackEvent } from '../../../../../../../_common/analytics/track-event.directive';
 import { Api } from '../../../../../../../_common/api/api.service';
 import { Environment } from '../../../../../../../_common/environment/environment.service';
 import { GameBuild } from '../../../../../../../_common/game/build/build.model';
@@ -40,9 +39,6 @@ const DownloadDelay = 3000;
 		AppGameOgrs,
 		AppDiscoverGamesViewOverviewDetails,
 		AppAdPlaywireVideo,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 @RouteResolver({

--- a/src/app/views/discover/games/view/overview/overview.ts
+++ b/src/app/views/discover/games/view/overview/overview.ts
@@ -2,7 +2,6 @@ import { Component } from 'vue-property-decorator';
 import { Ads } from '../../../../../../_common/ad/ads.service';
 import AppAdPlacement from '../../../../../../_common/ad/placement/placement.vue';
 import AppAdWidget from '../../../../../../_common/ad/widget/widget.vue';
-import { AppTrackEvent } from '../../../../../../_common/analytics/track-event.directive';
 import { Api } from '../../../../../../_common/api/api.service';
 import AppCard from '../../../../../../_common/card/card.vue';
 import { Clipboard } from '../../../../../../_common/clipboard/clipboard-service';
@@ -73,9 +72,6 @@ import AppDiscoverGamesViewOverviewSupporters from './_supporters/supporters.vue
 		AppGamePerms,
 		AppContentViewer,
 		AppUserKnownFollowers,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 	filters: {
 		number,

--- a/src/app/views/discover/home/_banner/banner.ts
+++ b/src/app/views/discover/home/_banner/banner.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { Location } from 'vue-router';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import AppCommunityJoinWidget from '../../../../../_common/community/join-widget/join-widget.vue';
 import { Jam } from '../../../../../_common/jam/jam.model';
 import { Screen } from '../../../../../_common/screen/screen-service';
@@ -16,9 +15,6 @@ import { Store } from '../../../../store/index';
 		AppGameFollowWidget,
 		AppTheme,
 		AppCommunityJoinWidget,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppDiscoverHomeBanner extends Vue {

--- a/src/app/views/discover/home/_tags/tags.ts
+++ b/src/app/views/discover/home/_tags/tags.ts
@@ -1,14 +1,10 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import AppTagList from '../../../../components/tag/list/list.vue';
 
 @Component({
 	components: {
 		AppTagList,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 export default class AppDiscoverHomeTags extends Vue {}

--- a/src/app/views/discover/home/home.ts
+++ b/src/app/views/discover/home/home.ts
@@ -1,6 +1,5 @@
 import { Component } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { Api } from '../../../../_common/api/api.service';
 import { Community } from '../../../../_common/community/community.model';
 import { Environment } from '../../../../_common/environment/environment.service';
@@ -25,9 +24,6 @@ import AppDiscoverHomeTags from './_tags/tags.vue';
 		AppGameGrid,
 		AppGameGridPlaceholder,
 		AppAuthJoin: AppAuthJoinLazy,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 @RouteResolver({

--- a/src/app/views/forums/topics/view/view.ts
+++ b/src/app/views/forums/topics/view/view.ts
@@ -1,7 +1,6 @@
 import { Component } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { enforceLocation } from '../../../../../utils/router';
-import { AppTrackEvent } from '../../../../../_common/analytics/track-event.directive';
 import { Api } from '../../../../../_common/api/api.service';
 import AppContentViewer from '../../../../../_common/content/content-viewer/content-viewer.vue';
 import { Environment } from '../../../../../_common/environment/environment.service';
@@ -27,7 +26,6 @@ import { AppTooltip } from '../../../../../_common/tooltip/tooltip';
 import AppUserCardHover from '../../../../../_common/user/card/hover/hover.vue';
 import AppUserAvatar from '../../../../../_common/user/user-avatar/user-avatar.vue';
 import AppUserVerifiedTick from '../../../../../_common/user/verified-tick/verified-tick.vue';
-import { Store } from '../../../../store/index';
 import FormForumPost from '../../../../components/forms/forum/post/post.vue';
 import FormForumTopic from '../../../../components/forms/forum/topic/topic.vue';
 import AppForumBreadcrumbs from '../../../../components/forum/breadcrumbs/breadcrumbs.vue';
@@ -35,6 +33,7 @@ import AppForumPostList from '../../../../components/forum/post-list/post-list.v
 import AppForumTopicUpvoteWidget from '../../../../components/forum/topic/upvote-widget/upvote-widget.vue';
 import AppPageHeaderControls from '../../../../components/page-header/controls/controls.vue';
 import AppPageHeader from '../../../../components/page-header/page-header.vue';
+import { Store } from '../../../../store/index';
 
 @Component({
 	name: 'RouteForumsTopicsView',
@@ -60,7 +59,6 @@ import AppPageHeader from '../../../../components/page-header/page-header.vue';
 	directives: {
 		AppTooltip,
 		AppScrollTo,
-		AppTrackEvent,
 	},
 	filters: {
 		number,
@@ -109,7 +107,9 @@ export default class RouteForumsTopicsView extends BaseRouteComponent {
 	readonly Environment = Environment;
 
 	get loginUrl() {
-		return Environment.authBaseUrl + '/login?redirect=' + encodeURIComponent(this.$route.fullPath);
+		return (
+			Environment.authBaseUrl + '/login?redirect=' + encodeURIComponent(this.$route.fullPath)
+		);
 	}
 
 	get sort() {

--- a/src/app/views/home/feed.ts
+++ b/src/app/views/home/feed.ts
@@ -3,7 +3,6 @@ import { Mutation, State } from 'vuex-class';
 import { numberSort } from '../../../utils/array';
 import { fuzzysearch } from '../../../utils/string';
 import AppAdPlaywireVideo from '../../../_common/ad/playwire/video.vue';
-import { AppTrackEvent } from '../../../_common/analytics/track-event.directive';
 import { Api } from '../../../_common/api/api.service';
 import { FiresidePost } from '../../../_common/fireside/post/post-model';
 import { Meta } from '../../../_common/meta/meta-service';
@@ -45,9 +44,6 @@ class DashGame {
 		AppScrollAffix,
 		AppAdPlaywireVideo,
 		AppHomeRecommended,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 @RouteResolver({

--- a/src/app/views/landing/client/client.ts
+++ b/src/app/views/landing/client/client.ts
@@ -1,5 +1,4 @@
 import { Component } from 'vue-property-decorator';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { Api } from '../../../../_common/api/api.service';
 import { Device } from '../../../../_common/device/device.service';
 import { Game } from '../../../../_common/game/game.model';
@@ -17,7 +16,6 @@ import { AppThemeSvg } from '../../../../_common/theme/svg/svg';
 		AppThemeSvg,
 	},
 	directives: {
-		AppTrackEvent,
 		AppScrollTo,
 	},
 })

--- a/src/app/views/landing/marketplace/marketplace.ts
+++ b/src/app/views/landing/marketplace/marketplace.ts
@@ -1,6 +1,5 @@
 import { Component } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
 import { Api } from '../../../../_common/api/api.service';
 import { FiresidePost } from '../../../../_common/fireside/post/post-model';
 import { Game } from '../../../../_common/game/game.model';
@@ -9,8 +8,8 @@ import { Meta } from '../../../../_common/meta/meta-service';
 import { BaseRouteComponent, RouteResolver } from '../../../../_common/route/route-component';
 import { Screen } from '../../../../_common/screen/screen-service';
 import { AppThemeSvg } from '../../../../_common/theme/svg/svg';
-import { Store } from '../../../store/index';
 import { AppAuthJoinLazy } from '../../../components/lazy';
+import { Store } from '../../../store/index';
 
 @Component({
 	name: 'RouteLandingMarketplace',
@@ -18,9 +17,6 @@ import { AppAuthJoinLazy } from '../../../components/lazy';
 		AppGameThumbnail,
 		AppAuthJoin: AppAuthJoinLazy,
 		AppThemeSvg,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 @RouteResolver({

--- a/src/app/views/profile/videos/videos.ts
+++ b/src/app/views/profile/videos/videos.ts
@@ -1,18 +1,14 @@
-import { AppTrackEvent } from '../../../../_common/analytics/track-event.directive';
+import { Component } from 'vue-property-decorator';
 import { Api } from '../../../../_common/api/api.service';
 import AppCommentVideoThumbnail from '../../../../_common/comment/video/thumbnail/thumbnail.vue';
 import { CommentVideo } from '../../../../_common/comment/video/video-model';
 import { BaseRouteComponent, RouteResolver } from '../../../../_common/route/route-component';
-import { Component } from 'vue-property-decorator';
 import { RouteStore, RouteStoreModule } from '../profile.store';
 
 @Component({
 	name: 'RouteProfileVideos',
 	components: {
 		AppCommentVideoThumbnail,
-	},
-	directives: {
-		AppTrackEvent,
 	},
 })
 @RouteResolver({


### PR DESCRIPTION
The reasoning:
- we already load up Analytics service on every single section by default and the only dependency for the directive is Analytics service
- it's only like 15 lines of code
- we want to track as many events as possible, so let's make it easy to