### PR TITLE
Show "copy link" actions in the ... dropdown for posts, games, users, communities.

### DIFF
--- a/src/app/components/event-item/controls/fireside-post/extra/extra.ts
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import { Component, Emit, Prop } from 'vue-property-decorator';
 import { Mutation } from 'vuex-class';
 import { Api } from '../../../../../../_common/api/api.service';
+import { Clipboard } from '../../../../../../_common/clipboard/clipboard-service';
 import { CommunityChannel } from '../../../../../../_common/community/channel/channel.model';
 import { Community } from '../../../../../../_common/community/community.model';
 import { Environment } from '../../../../../../_common/environment/environment.service';
@@ -169,6 +170,10 @@ export default class AppEventItemControlsFiresidePostExtra extends Vue {
 	async rejectFromCommunity(postCommunity: FiresidePostCommunity) {
 		await this.post.$reject(postCommunity.community);
 		this.emitReject(postCommunity.community);
+	}
+
+	copyShareUrl() {
+		Clipboard.copy(this.post.url);
 	}
 
 	report() {

--- a/src/app/components/event-item/controls/fireside-post/extra/extra.vue
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.vue
@@ -24,6 +24,15 @@
 			</template>
 
 			<div class="list-group list-group-dark">
+				<a
+					class="list-group-item has-icon"
+					@click="copyShareUrl"
+					v-app-track-event="`copy-link:post`"
+				>
+					<app-jolticon icon="link" />
+					<translate>Copy link to post</translate>
+				</a>
+
 				<template v-if="shouldShowPins">
 					<a class="list-group-item has-icon" v-if="post.is_pinned" @click="unpin">
 						<app-jolticon icon="thumbtack" />
@@ -40,11 +49,11 @@
 					<span v-for="i of post.manageableCommunities" :key="i.id">
 						<app-community-perms :community="i.community" required="community-features">
 							<a class="list-group-item has-icon" @click.stop="toggleFeatured(i)">
+								<app-jolticon icon="tag" />
 								<template v-if="i.isFeatured">
-									<app-jolticon icon="remove" />
 									<template v-if="shouldDisplayCommunityName(i.community)">
 										<translate :translate-params="{ community: i.community.name }">
-											Unfeature : %{ community }
+											Unfeature from %{ community }
 										</translate>
 									</template>
 									<template v-else>
@@ -54,10 +63,9 @@
 									</template>
 								</template>
 								<template v-else>
-									<app-jolticon icon="tag" />
 									<template v-if="shouldDisplayCommunityName(i.community)">
 										<translate :translate-params="{ community: i.community.name }">
-											Feature : %{ community }
+											Feature in %{ community }
 										</translate>
 									</template>
 									<template v-else>
@@ -76,12 +84,12 @@
 							</a>
 
 							<a class="list-group-item has-icon" @click.stop="rejectFromCommunity(i)">
-								<app-jolticon icon="remove" notice />
+								<app-jolticon icon="remove" />
 
 								<translate :translate-params="{ community: i.community.name }">
 									Eject
 									<template v-if="shouldDisplayCommunityName(i.community)">
-										: %{ community }
+										from %{ community }
 									</template>
 									<template v-else>
 										from this community
@@ -94,14 +102,14 @@
 
 				<!-- User reports -->
 				<a class="list-group-item has-icon" v-if="user && user.id !== post.user.id" @click="report">
-					<app-jolticon icon="flag" notice />
-					<translate>Report Post</translate>
+					<app-jolticon icon="flag" />
+					<translate>Report post</translate>
 				</a>
 
 				<!-- Remove -->
 				<a v-if="canEdit" class="list-group-item has-icon" @click.stop="remove()">
 					<app-jolticon icon="remove" notice />
-					<translate>Remove Post</translate>
+					<translate>Remove</translate>
 				</a>
 
 				<!-- Moderate -->
@@ -112,7 +120,7 @@
 					target="_blank"
 				>
 					<app-jolticon icon="cog" />
-					<translate>Moderate Post</translate>
+					<translate>Moderate</translate>
 				</a>
 			</div>
 		</div>

--- a/src/app/components/event-item/controls/fireside-post/fireside-post.ts
+++ b/src/app/components/event-item/controls/fireside-post/fireside-post.ts
@@ -1,19 +1,14 @@
 import Vue from 'vue';
 import { Component, Emit, Prop } from 'vue-property-decorator';
 import { AppAuthRequired } from '../../../../../_common/auth/auth-required-directive';
-import { Clipboard } from '../../../../../_common/clipboard/clipboard-service';
 import { CommentModal } from '../../../../../_common/comment/modal/modal.service';
 import AppCommentVideoLikeWidget from '../../../../../_common/comment/video/like-widget/like-widget.vue';
 import { CommunityChannel } from '../../../../../_common/community/channel/channel.model';
 import { Community } from '../../../../../_common/community/community.model';
-import { Environment } from '../../../../../_common/environment/environment.service';
 import { number } from '../../../../../_common/filters/number';
 import AppFiresidePostLikeWidget from '../../../../../_common/fireside/post/like/widget/widget.vue';
 import { FiresidePost } from '../../../../../_common/fireside/post/post-model';
-import AppPopper from '../../../../../_common/popper/popper.vue';
 import { Screen } from '../../../../../_common/screen/screen-service';
-import { AppSocialFacebookLike } from '../../../../../_common/social/facebook/like/like';
-import { AppSocialTwitterShare } from '../../../../../_common/social/twitter/share/share';
 import { AppState, AppStore } from '../../../../../_common/store/app-store';
 import { AppTooltip } from '../../../../../_common/tooltip/tooltip';
 import { User } from '../../../../../_common/user/user.model';
@@ -24,12 +19,9 @@ import AppEventItemControlsFiresidePostStats from './stats/stats.vue';
 
 @Component({
 	components: {
-		AppPopper,
 		AppCommentWidget: AppCommentWidgetLazy,
 		AppFiresidePostLikeWidget,
 		AppCommentVideoLikeWidget,
-		AppSocialTwitterShare,
-		AppSocialFacebookLike,
 		AppEventItemControlsFiresidePostStats,
 		AppEventItemControlsFiresidePostExtra,
 	},
@@ -56,8 +48,6 @@ export default class AppEventItemControlsFiresidePost extends Vue {
 
 	@AppState
 	user!: AppStore['user'];
-
-	isShowingShare = false;
 
 	readonly GJ_IS_CLIENT!: boolean;
 
@@ -96,10 +86,6 @@ export default class AppEventItemControlsFiresidePost extends Vue {
 		return this.post.isActive;
 	}
 
-	get shareUrl() {
-		return Environment.baseUrl + this.$router.resolve(this.post.routeLocation).href;
-	}
-
 	get hasPerms() {
 		if (!this.user) {
 			return false;
@@ -121,10 +107,6 @@ export default class AppEventItemControlsFiresidePost extends Vue {
 
 	get shouldShowStatsInNewLine() {
 		return Screen.isXs;
-	}
-
-	copyShareUrl() {
-		Clipboard.copy(this.shareUrl);
 	}
 
 	openComments() {

--- a/src/app/components/event-item/controls/fireside-post/fireside-post.vue
+++ b/src/app/components/event-item/controls/fireside-post/fireside-post.vue
@@ -31,24 +31,6 @@
 
 					&nbsp;
 				</template>
-
-				<app-popper @show="isShowingShare = true" @hide="isShowingShare = false">
-					<app-button icon="share-airplane" circle trans v-app-tooltip="$gettext('Share')" />
-
-					<div slot="popover" class="well fill-darkest sans-margin" v-if="isShowingShare">
-						<div class="social-widgets" v-if="!GJ_IS_CLIENT">
-							<app-social-twitter-share :url="shareUrl" :content="post.leadStr" />
-
-							<span class="dot-separator"></span>
-
-							<app-social-facebook-like :url="shareUrl" />
-						</div>
-
-						<app-button block @click="copyShareUrl">
-							<translate>Copy Permalink</translate>
-						</app-button>
-					</div>
-				</app-popper>
 			</div>
 
 			<app-event-item-controls-fireside-post-stats

--- a/src/app/views/communities/view/view.ts
+++ b/src/app/views/communities/view/view.ts
@@ -3,6 +3,7 @@ import { Component } from 'vue-property-decorator';
 import { Action, Mutation, State } from 'vuex-class';
 import { enforceLocation } from '../../../../utils/router';
 import { Api } from '../../../../_common/api/api.service';
+import { Clipboard } from '../../../../_common/clipboard/clipboard-service';
 import { Collaborator } from '../../../../_common/collaborator/collaborator.model';
 import { Community } from '../../../../_common/community/community.model';
 import AppCommunityJoinWidget from '../../../../_common/community/join-widget/join-widget.vue';
@@ -145,6 +146,12 @@ export default class RouteCommunitiesView extends BaseRouteComponent {
 
 	showEditHeader() {
 		CommunityHeaderModal.show(this.community);
+	}
+
+	copyShareUrl() {
+		Clipboard.copy(
+			Environment.baseUrl + this.$router.resolve(this.community.routeLocation).href
+		);
 	}
 
 	async acceptCollaboration() {

--- a/src/app/views/communities/view/view.vue
+++ b/src/app/views/communities/view/view.vue
@@ -79,14 +79,23 @@
 						</router-link>
 					</li>
 
-					<li v-if="shouldShowModTools">
+					<li>
 						<app-popper>
 							<a>
-								<app-jolticon icon="ellipsis-h" />
+								<app-jolticon icon="ellipsis-v" />
 							</a>
 
 							<div slot="popover" class="list-group list-group-dark">
 								<a
+									class="list-group-item has-icon"
+									@click="copyShareUrl"
+									v-app-track-event="`copy-link:community`"
+								>
+									<app-jolticon icon="link" />
+									<translate>Copy link to community</translate>
+								</a>
+								<a
+									v-if="shouldShowModTools"
 									class="list-group-item has-icon"
 									:href="Environment.baseUrl + `/moderate/communities/view/${community.id}`"
 									target="_blank"

--- a/src/app/views/discover/games/view/_nav/nav.ts
+++ b/src/app/views/discover/games/view/_nav/nav.ts
@@ -1,15 +1,17 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { State } from 'vuex-class';
+import { Clipboard } from '../../../../../../_common/clipboard/clipboard-service';
 import { CommentState, CommentStore } from '../../../../../../_common/comment/comment-store';
 import { CommentModal } from '../../../../../../_common/comment/modal/modal.service';
+import { Environment } from '../../../../../../_common/environment/environment.service';
 import { number } from '../../../../../../_common/filters/number';
 import AppPopper from '../../../../../../_common/popper/popper.vue';
 import { ReportModal } from '../../../../../../_common/report/modal/modal.service';
 import { Screen } from '../../../../../../_common/screen/screen-service';
-import { Store } from '../../../../../store/index';
 import AppGameModLinks from '../../../../../components/game/mod-links/mod-links.vue';
 import { AppGamePerms } from '../../../../../components/game/perms/perms';
+import { Store } from '../../../../../store/index';
 import { RouteStore, RouteStoreModule } from '../view.store';
 
 @Component({
@@ -61,6 +63,10 @@ export default class AppDiscoverGamesViewNav extends Vue {
 
 	showComments() {
 		CommentModal.show({ resource: 'Game', resourceId: this.game.id, displayMode: 'comments' });
+	}
+
+	copyShareUrl() {
+		Clipboard.copy(Environment.baseUrl + this.$router.resolve(this.game.routeLocation).href);
 	}
 
 	report() {

--- a/src/app/views/discover/games/view/_nav/nav.vue
+++ b/src/app/views/discover/games/view/_nav/nav.vue
@@ -29,7 +29,7 @@
 					</router-link>
 				</li>
 
-				<li v-if="hasScores">
+				<li v-if="hasScores && primaryScoreTable">
 					<router-link
 						:to="{
 							name: 'discover.games.view.scores.list',
@@ -51,13 +51,21 @@
 					</router-link>
 				</li>
 
-				<li v-if="app.user">
+				<li>
 					<app-popper>
 						<a>
-							<app-jolticon icon="ellipsis-h" />
+							<app-jolticon icon="ellipsis-v" />
 						</a>
 
 						<div slot="popover" class="list-group list-group-dark">
+							<a
+								class="list-group-item has-icon"
+								@click="copyShareUrl"
+								v-app-track-event="`copy-link:game`"
+							>
+								<app-jolticon icon="link" />
+								<translate>Copy link to game</translate>
+							</a>
 							<app-game-perms :game="game">
 								<router-link
 									class="list-group-item has-icon"
@@ -67,12 +75,12 @@
 									}"
 								>
 									<app-jolticon icon="cog" />
-									<translate>Manage Game</translate>
+									<translate>Manage game</translate>
 								</router-link>
 							</app-game-perms>
 							<a class="list-group-item has-icon" v-if="app.user && !hasAnyPerms" @click="report">
-								<app-jolticon icon="flag" notice />
-								<translate>games.view.report_game_button</translate>
+								<app-jolticon icon="flag" />
+								<translate>Report game</translate>
 							</a>
 							<app-game-mod-links v-if="shouldShowModTools" :game="game" />
 						</div>

--- a/src/app/views/profile/profile.ts
+++ b/src/app/views/profile/profile.ts
@@ -1,6 +1,7 @@
 import { Component } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { Api } from '../../../_common/api/api.service';
+import { Clipboard } from '../../../_common/clipboard/clipboard-service';
 import { CommentModal } from '../../../_common/comment/modal/modal.service';
 import { Environment } from '../../../_common/environment/environment.service';
 import { number } from '../../../_common/filters/number';
@@ -155,6 +156,13 @@ export default class RouteProfile extends BaseRouteComponent {
 				displayMode: 'shouts',
 			});
 		}
+	}
+
+	copyShareUrl() {
+		if (!this.user) {
+			return;
+		}
+		Clipboard.copy(Environment.baseUrl + this.user.url);
 	}
 
 	report() {

--- a/src/app/views/profile/profile.vue
+++ b/src/app/views/profile/profile.vue
@@ -131,26 +131,27 @@
 								</span>
 							</router-link>
 						</li>
-						<li
-							v-if="
-								app.user &&
-									(app.user.permission_level > 0 ||
-										(userFriendship && userFriendship.state) === UserFriendship.STATE_FRIENDS ||
-										user.id !== app.user.id)
-							"
-						>
+						<li>
 							<app-popper>
 								<a>
-									<app-jolticon icon="ellipsis-h" />
+									<app-jolticon icon="ellipsis-v" />
 								</a>
 
 								<div slot="popover" class="list-group list-group-dark">
 									<a
 										class="list-group-item has-icon"
+										@click="copyShareUrl"
+										v-app-track-event="`copy-link:user`"
+									>
+										<app-jolticon icon="link" />
+										<translate>Copy link to user</translate>
+									</a>
+									<a
+										class="list-group-item has-icon"
 										v-if="app.user && user.id !== app.user.id"
 										@click="report"
 									>
-										<app-jolticon icon="flag" notice />
+										<app-jolticon icon="flag" />
 										<translate>profile.report_user_button</translate>
 									</a>
 									<a


### PR DESCRIPTION
- Removed the "share" airplane from posts. Instead it now shows in the ...
- Added copy link into all the ... menus, makes it easier to copy the link from client and mobile.

We only seem to be getting 20-30 supposed social likes/tweets per day, but I don't really see that reflected in the twitter search. I don't think people are really using the share buttons, and it makes more sense to hit ... to get the link for myself.