### PR TITLE
Embed videos into post feeds immediately.

### DIFF
--- a/src/_common/comment/video/modal/modal.vue
+++ b/src/_common/comment/video/modal/modal.vue
@@ -13,7 +13,7 @@
 						v-if="video"
 						video-provider="youtube"
 						:video-id="video.video_id"
-						:autoplay="true"
+						autoplay
 					/>
 				</app-responsive-dimensions>
 			</div>

--- a/src/_common/media-bar/lightbox/item/item.vue
+++ b/src/_common/media-bar/lightbox/item/item.vue
@@ -32,7 +32,7 @@
 						:video-id="item.url"
 						:max-video-width="maxWidth"
 						:max-video-height="maxHeight"
-						:autoplay="true"
+						autoplay
 					/>
 				</div>
 

--- a/src/app/components/activity/feed/_video/video.vue
+++ b/src/app/components/activity/feed/_video/video.vue
@@ -1,19 +1,7 @@
 <template>
 	<div class="-video-embed">
 		<app-responsive-dimensions :ratio="16 / 9" @change="onDimensionsChange()">
-			<a v-if="!isHydrated || !isShowingVideo" @click.stop="play">
-				<div class="play-button-overlay">
-					<app-jolticon icon="play" />
-				</div>
-
-				<div class="-thumb" :style="{ 'background-image': `url('${thumbnail}')` }"></div>
-			</a>
-			<app-video-embed
-				v-else
-				video-provider="youtube"
-				:video-id="videoId"
-				:autoplay="shouldAutoplay"
-			/>
+			<app-video-embed v-if="isHydrated" video-provider="youtube" :video-id="videoId" />
 		</app-responsive-dimensions>
 	</div>
 </template>
@@ -27,25 +15,11 @@
 	margin-top: $-item-padding-xs-v
 	margin-left: -($-item-padding-xs)
 	margin-right: -($-item-padding-xs)
-	position: relative
 
 	@media $media-sm-up
 		margin-top: $-item-padding-v
 		margin-left: -($-item-padding-container)
 		margin-right: -($-item-padding-container)
-
-	a
-		display: block
-
-.-thumb
-	position: absolute
-	top: 0
-	right: 0
-	bottom: 0
-	left: 0
-	background-repeat: no-repeat
-	background-position: center center
-	background-size: cover
 </style>
 
 <script lang="ts" src="./video"></script>

--- a/src/app/components/broadcast-modal/broadcast-modal.vue
+++ b/src/app/components/broadcast-modal/broadcast-modal.vue
@@ -71,7 +71,7 @@
 						<app-video-embed
 							video-provider="youtube"
 							:video-id="post.videos[0].video_id"
-							:autoplay="true"
+							autoplay
 						/>
 
 						<br />

--- a/src/app/components/post/view/view.vue
+++ b/src/app/components/post/view/view.vue
@@ -4,12 +4,7 @@
 
 		<div class="container">
 			<div v-if="post.hasVideo" class="full-bleed-xs">
-				<app-video-embed
-					video-provider="youtube"
-					:video-id="post.videos[0].video_id"
-					:autoplay="true"
-				/>
-
+				<app-video-embed video-provider="youtube" :video-id="post.videos[0].video_id" autoplay />
 				<br />
 			</div>
 


### PR DESCRIPTION
It used to show a play button and then when you'd press that it would embed the iframe and try to autoplay the video.

The issue is that on mobile it wouldn't autoplay, so you'd have to press twice.