### PR TITLE
placed community unread notifications on their respective images

### DIFF
--- a/src/app/components/community/slider/item/item.styl
+++ b/src/app/components/community/slider/item/item.styl
@@ -5,12 +5,8 @@
 .-bubble
 	img-circle()
 	padding: 2px
-	margin-left: -4px
 	margin-right: -4px
-
-	.-unread &
-		margin-left: 0
-		margin-right: 0
+	position: relative
 
 .-thumb
 	img-circle()
@@ -43,8 +39,8 @@
 
 .-feature-counter
 	position: absolute
-	right: -2px
-	bottom: -2px
+	right: 4px
+	bottom: 4px
 	z-index: 2
 	border-radius: 10px
 	border-color: var(--theme-bg-actual)

--- a/src/app/components/community/slider/item/item.styl
+++ b/src/app/components/community/slider/item/item.styl
@@ -5,7 +5,8 @@
 .-bubble
 	img-circle()
 	padding: 2px
-	margin-right: -4px
+	margin-left: -2px
+	margin-right: -2px
 	position: relative
 
 .-thumb

--- a/src/app/components/community/slider/item/item.vue
+++ b/src/app/components/community/slider/item/item.vue
@@ -18,13 +18,13 @@
 			}"
 		>
 			<app-community-thumbnail-img class="-thumb" :community="community" />
+			<div v-if="featureCount > 0" class="-feature-counter">
+				{{ featureCountText }}
+			</div>
 		</div>
 
 		<div class="-label">
 			{{ community.name }}
-		</div>
-		<div v-if="featureCount > 0" class="-feature-counter">
-			{{ featureCountText }}
 		</div>
 	</router-link>
 </template>


### PR DESCRIPTION
- moved the unread notifications to line up like they do in the cbar
- adjusted community bubble margins so it doesn't shift around whether or not it's unread. Image should stay in the same place and just have the bubble gradient and notification bubble show if it's unread now.

![image](https://user-images.githubusercontent.com/2914500/75121048-92ead700-565e-11ea-9df3-275f37e44ed2.png)
