### PR TITLE
Trigger a "screen resize" event when the cbar mounts/unmounts.

### DIFF
--- a/src/app/components/shell/cbar/cbar.ts
+++ b/src/app/components/shell/cbar/cbar.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import AppScrollScroller from '../../../../_common/scroll/scroller/scroller.vue';
-import { AppState, AppStore } from '../../../../_common/store/app-store';
 import { AppTooltip } from '../../../../_common/tooltip/tooltip';
 import { Store } from '../../../store';
 import AppShellCbarAddItem from './add-item/add-item.vue';
@@ -19,13 +18,6 @@ import AppShellCbarItem from './item/item.vue';
 	},
 })
 export default class AppShellCbar extends Vue {
-	@AppState
-	user!: AppStore['user'];
-
 	@State
 	communities!: Store['communities'];
-
-	get shouldShow() {
-		return !!this.user;
-	}
 }

--- a/src/app/components/shell/cbar/cbar.vue
+++ b/src/app/components/shell/cbar/cbar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div id="shell-cbar" v-if="shouldShow">
+	<div id="shell-cbar">
 		<app-scroll-scroller class="-scroller" overlay hide-scrollbar>
 			<div class="-inner">
 				<transition-group name="-items">

--- a/src/app/components/shell/shell.ts
+++ b/src/app/components/shell/shell.ts
@@ -145,6 +145,14 @@ export default class AppShell extends Vue {
 		}
 	}
 
+	// Since the cbar takes up width from the whole screen, we want to trigger a
+	// screen "resize" event so that content can recalculate.
+	@Watch('hasCbar')
+	async onShouldShowChange() {
+		await this.$nextTick();
+		Screen._onResize();
+	}
+
 	// Keep the title up to date with notification counts.
 	@Watch('totalChatNotificationsCount')
 	@Watch('unreadActivityCount')

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -144,7 +144,7 @@ export class Store extends VuexStore<Store, Actions, Mutations> {
 	}
 
 	get hasCbar() {
-		return !this.isShellHidden && !Screen.isXs && this.communities.length;
+		return !this.isShellHidden && !Screen.isXs && this.communities.length && !!this.app.user;
 	}
 
 	get isLeftPaneVisible() {


### PR DESCRIPTION
This allows all components to recalc things since the viewable content area basically resized even if the screen didn't.