### PR TITLE
Don't let the "main" col overflow in page-container.

### DIFF
--- a/src/app/components/page-container/page-container.styl
+++ b/src/app/components/page-container/page-container.styl
@@ -42,6 +42,7 @@ $-main-max-width = 650px
 	.-main
 		flex: 2 0
 		max-width: $-main-max-width
+		overflow: hidden
 		order: 1
 
 	.-right


### PR DESCRIPTION
This should fix the bug where the page-container sometimes gets too large to show on the page.