### PR TITLE
Fix You tab breaking store in comment modals

### DIFF
--- a/src/_common/comment/comment-store.ts
+++ b/src/_common/comment/comment-store.ts
@@ -206,7 +206,7 @@ export class CommentStore extends VuexStore<CommentStore, CommentActions, Commen
 		const { store, count } = payload;
 		store.count = count;
 
-		if (count) {
+		if (count && store.sort !== Comment.SORT_YOU) {
 			store.totalCount = count;
 		}
 	}

--- a/src/_common/comment/comment-store.ts
+++ b/src/_common/comment/comment-store.ts
@@ -74,7 +74,6 @@ export class CommentStoreModel {
 		this.comments = [];
 		this.count = 0;
 		this.parentCount = 0;
-		--this.locks;
 	}
 
 	afterModification() {

--- a/src/_common/comment/modal/modal.ts
+++ b/src/_common/comment/modal/modal.ts
@@ -29,7 +29,7 @@ export default class AppCommentModal extends BaseModal {
 
 	get commentsCount() {
 		const store = this.getCommentStore(this.resource, this.resourceId);
-		return store ? store.count : 0;
+		return store ? store.totalCount : 0;
 	}
 
 	get autofocusAdd() {

--- a/src/_common/comment/widget/widget.ts
+++ b/src/_common/comment/widget/widget.ts
@@ -233,7 +233,10 @@ export default class AppCommentWidget extends Vue {
 		// need this data when closing the last widget to do some tear down
 		// work.
 		const metadata = this.store.metadata;
-		metadata.widgetLocks = metadata.widgetLocks ? metadata.widgetLocks + 1 : 1;
+		if (!metadata.widgetLocks) {
+			metadata.widgetLocks = 1;
+		}
+		metadata.widgetLocks += 1;
 	}
 
 	private async _releaseStore() {

--- a/src/_common/comment/widget/widget.ts
+++ b/src/_common/comment/widget/widget.ts
@@ -215,6 +215,10 @@ export default class AppCommentWidget extends Vue {
 			this.store = null;
 		}
 
+		const resource = this.resource;
+		const resourceId = this.resourceId;
+		this.store = await this.lockCommentStore({ resource, resourceId });
+
 		if (this.isThreadView && this.threadCommentId) {
 			this.storeView = new CommentStoreThreadView(this.threadCommentId);
 		} else {
@@ -225,13 +229,12 @@ export default class AppCommentWidget extends Vue {
 	}
 
 	private async _fetchComments() {
+		if (!this.store) {
+			throw new Error(`You need a store set before fetching comments.`);
+		}
+
 		try {
 			this.isLoading = true;
-
-			const resource = this.resource;
-			const resourceId = this.resourceId;
-
-			this.store = await this.lockCommentStore({ resource, resourceId });
 
 			let payload: any;
 			if (this.isThreadView && this.threadCommentId) {
@@ -320,11 +323,13 @@ export default class AppCommentWidget extends Vue {
 	}
 
 	private _setSort(sort: string) {
-		if (this.store) {
-			this.currentPage = 1;
-			this.setSort({ store: this.store, sort: sort });
-			this._fetchComments();
+		if (!this.store) {
+			return;
 		}
+
+		this.currentPage = 1;
+		this.setSort({ store: this.store, sort: sort });
+		this._fetchComments();
 	}
 
 	loadMore() {

--- a/src/_common/comment/widget/widget.ts
+++ b/src/_common/comment/widget/widget.ts
@@ -133,8 +133,8 @@ export default class AppCommentWidget extends Vue {
 		return this.store ? this.store.childComments : [];
 	}
 
-	get commentsCount() {
-		return this.store ? this.store.count : 0;
+	get totalCommentsCount() {
+		return this.store ? this.store.totalCount : 0;
 	}
 
 	get totalParentCount() {
@@ -186,7 +186,7 @@ export default class AppCommentWidget extends Vue {
 			return false;
 		}
 
-		return this.comments.length > 0;
+		return this.totalCommentsCount > 0;
 	}
 
 	async created() {
@@ -231,9 +231,7 @@ export default class AppCommentWidget extends Vue {
 			const resource = this.resource;
 			const resourceId = this.resourceId;
 
-			if (!this.store) {
-				this.store = await this.lockCommentStore({ resource, resourceId });
-			}
+			this.store = await this.lockCommentStore({ resource, resourceId });
 
 			let payload: any;
 			if (this.isThreadView && this.threadCommentId) {

--- a/src/_common/comment/widget/widget.ts
+++ b/src/_common/comment/widget/widget.ts
@@ -234,7 +234,7 @@ export default class AppCommentWidget extends Vue {
 		// work.
 		const metadata = this.store.metadata;
 		if (!metadata.widgetLocks) {
-			metadata.widgetLocks = 1;
+			metadata.widgetLocks = 0;
 		}
 		metadata.widgetLocks += 1;
 	}

--- a/src/app/components/event-item/controls/comments/comments.ts
+++ b/src/app/components/event-item/controls/comments/comments.ts
@@ -46,7 +46,7 @@ export default class AppEventItemControlsComments extends Vue {
 	clickedCommentType = '';
 
 	get commentsCount() {
-		return this.commentStore ? this.commentStore.count : 0;
+		return this.commentStore ? this.commentStore.totalCount : 0;
 	}
 
 	get resource() {

--- a/src/app/views/discover/games/view/_nav/nav.ts
+++ b/src/app/views/discover/games/view/_nav/nav.ts
@@ -56,7 +56,7 @@ export default class AppDiscoverGamesViewNav extends Vue {
 	get commentsCount() {
 		if (this.game) {
 			const store = this.getCommentStore('Game', this.game.id);
-			return store ? store.count : 0;
+			return store ? store.totalCount : 0;
 		}
 		return 0;
 	}

--- a/src/app/views/discover/games/view/overview/overview.ts
+++ b/src/app/views/discover/games/view/overview/overview.ts
@@ -221,7 +221,7 @@ export default class RouteDiscoverGamesViewOverview extends BaseRouteComponent {
 	get commentsCount() {
 		if (this.game) {
 			const store = this.getCommentStore('Game', this.game.id);
-			return store ? store.count : 0;
+			return store ? store.totalCount : 0;
 		}
 		return 0;
 	}


### PR DESCRIPTION
Sorting comments by 'You' will now check the totalCount of comments instead of current count, so tabs will still show when you haven't commented yet.

Fixed some bugs where the comment modals would attach to a different store if you changed the sorting and then closed out of them.