### PR TITLE
Profile communities grid items now grow to fit container

### DIFF
--- a/src/app/views/profile/overview/overview.vue
+++ b/src/app/views/profile/overview/overview.vue
@@ -376,7 +376,7 @@
 .-communities
 	display: grid
 	grid-template-columns: repeat(5, minmax(55px, 1fr))
-	grid-gap: 10px
+	grid-gap: 8px
 
 .-community-item
 	pressy()
@@ -399,6 +399,9 @@
 .-community-thumb-placeholder
 	img-circle()
 	change-bg('bg-subtle')
+	// Setting 'padding-top' with a percentage goes off the elements width,
+	// rather than the height. This will allow us to use a 1:1 aspect ratio
+	// for the loading placeholders, matching them up with our thumbnails.
 	padding-top: 100%
 
 .-community-verified-tick

--- a/src/app/views/profile/overview/overview.vue
+++ b/src/app/views/profile/overview/overview.vue
@@ -375,21 +375,20 @@
 
 .-communities
 	display: grid
-	grid-template-columns: repeat(5, 55px)
-	grid-gap: 5px 10px
+	grid-template-columns: repeat(5, minmax(55px, 1fr))
+	grid-gap: 10px
 
 .-community-item
 	pressy()
 	display: inline-block
 	position: relative
 	outline: 0
-	width: 55px
-	height: 55px
+	width: 100%
+	height: auto
 
 .-community-thumb
 	img-circle()
 	change-bg('dark')
-	position: absolute
 	width: 100%
 	height: 100%
 
@@ -400,6 +399,7 @@
 .-community-thumb-placeholder
 	img-circle()
 	change-bg('bg-subtle')
+	padding-top: 100%
 
 .-community-verified-tick
 	position: absolute


### PR DESCRIPTION
Changed styling to allow grid items to expand past their initial value.
`padding-top: 100%` allows the loading placeholders to show within the grid.