### PR TITLE
Created initialTab prop for comment modals

### DIFF
--- a/src/_common/comment/comment-store.ts
+++ b/src/_common/comment/comment-store.ts
@@ -14,7 +14,7 @@ export const CommentMutation = namespace(CommentStoreNamespace, Mutation);
 
 export type CommentActions = {
 	'comment/lockCommentStore': { resource: string; resourceId: number };
-	'comment/fetchComments': { store: CommentStoreModel; page?: number };
+	'comment/fetchComments': { store: CommentStoreModel; page?: number; initialTab?: string };
 	'comment/pinComment': { comment: Comment };
 	'comment/setSort': { store: CommentStoreModel; sort: string };
 	'comment/fetchThread': { store: CommentStoreModel; parentId: number };
@@ -233,7 +233,7 @@ export class CommentStore extends VuexStore<CommentStore, CommentActions, Commen
 		const { store, count } = payload;
 		store.count = count;
 
-		if (count && store.sort !== Comment.SORT_YOU) {
+		if (count) {
 			store.totalCount = count;
 		}
 	}
@@ -297,8 +297,10 @@ export class CommentStore extends VuexStore<CommentStore, CommentActions, Commen
 				// reduce comment count by amount of child comments on this parent + 1 for the parent
 				const childAmount = store.comments.filter(c => c.parent_id === comment.id).length;
 				store.count -= childAmount + 1;
+				store.totalCount -= childAmount + 1;
 			} else {
 				--store.count;
+				--store.totalCount;
 			}
 			arrayRemove(store.comments, i => i.id === comment.id);
 			store.afterModification();

--- a/src/_common/comment/modal/modal.service.ts
+++ b/src/_common/comment/modal/modal.service.ts
@@ -7,11 +7,12 @@ export type DisplayMode = 'comments' | 'shouts';
 interface CommentModalOptions {
 	displayMode?: DisplayMode;
 	model: Model;
+	initialTab?: string;
 }
 
 export class CommentModal {
 	static async show(options: CommentModalOptions) {
-		const { displayMode, model } = options;
+		const { displayMode, model, initialTab } = options;
 
 		return await Modal.show<void>({
 			modalId: 'Comment-' + [model.constructor.name, model.id].join('-'),
@@ -20,6 +21,7 @@ export class CommentModal {
 			props: {
 				displayMode,
 				model,
+				initialTab,
 			},
 			size: 'sm',
 		});

--- a/src/_common/comment/modal/modal.ts
+++ b/src/_common/comment/modal/modal.ts
@@ -1,4 +1,5 @@
 import { Component, Prop } from 'vue-property-decorator';
+import { propOptional } from '../../../utils/vue';
 import { number } from '../../filters/number';
 import { BaseModal } from '../../modal/base';
 import { Model } from '../../model/model.service';
@@ -19,6 +20,9 @@ export default class AppCommentModal extends BaseModal {
 
 	@Prop(Model)
 	model!: Model;
+
+	@Prop(propOptional(String))
+	initialTab?: string;
 
 	@CommentState
 	getCommentStore!: CommentStore['getCommentStore'];

--- a/src/_common/comment/modal/modal.vue
+++ b/src/_common/comment/modal/modal.vue
@@ -28,7 +28,7 @@
 		</div>
 
 		<div class="modal-body">
-			<app-comment-widget :model="model" :autofocus="autofocusAdd" />
+			<app-comment-widget :model="model" :autofocus="autofocusAdd" :initial-tab="initialTab" />
 		</div>
 	</app-modal>
 </template>

--- a/src/_common/comment/widget/widget.ts
+++ b/src/_common/comment/widget/widget.ts
@@ -109,7 +109,6 @@ export default class AppCommentWidget extends Vue {
 	resourceOwner: User | null = null;
 	perPage = 10;
 	currentPage = 1;
-	tabSet = false;
 
 	collaborators: Collaborator[] = [];
 
@@ -226,6 +225,12 @@ export default class AppCommentWidget extends Vue {
 			this.storeView = new CommentStoreSliceView();
 		}
 
+		// Filter comments based on the 'initialTab' prop. This allows us to set the comment
+		// sorting to the "You" tab when you leave a comment from an event item.
+		if (this.store && this.initialTab) {
+			this.setSort({ store: this.store, sort: this.initialTab });
+		}
+
 		await this._fetchComments();
 	}
 
@@ -267,14 +272,6 @@ export default class AppCommentWidget extends Vue {
 	private async _fetchComments() {
 		if (!this.store) {
 			throw new Error(`You need a store set before fetching comments.`);
-		}
-
-		// Check to see if we received 'initialTab' as a prop. If so, we want to setSort()
-		// to filter comments based on that parameter. This allows us to set the comment
-		// sorting to the "You" tab when you leave a comment from an event item.
-		if (this.initialTab && !this.tabSet) {
-			this.setSort({ store: this.store, sort: this.initialTab });
-			this.tabSet = true;
 		}
 
 		try {

--- a/src/_common/comment/widget/widget.ts
+++ b/src/_common/comment/widget/widget.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
+import { propOptional } from '../../../utils/vue';
 import { Analytics } from '../../analytics/analytics.service';
 import { AppAuthRequired } from '../../auth/auth-required-directive';
 import { Collaborator } from '../../collaborator/collaborator.model';
@@ -63,6 +64,9 @@ export default class AppCommentWidget extends Vue {
 	@Prop({ type: Boolean, default: true })
 	showTabs!: boolean;
 
+	@Prop(propOptional(String))
+	initialTab?: string;
+
 	@AppState
 	user!: AppStore['user'];
 
@@ -105,6 +109,7 @@ export default class AppCommentWidget extends Vue {
 	resourceOwner: User | null = null;
 	perPage = 10;
 	currentPage = 1;
+	tabSet = false;
 
 	collaborators: Collaborator[] = [];
 
@@ -262,6 +267,14 @@ export default class AppCommentWidget extends Vue {
 	private async _fetchComments() {
 		if (!this.store) {
 			throw new Error(`You need a store set before fetching comments.`);
+		}
+
+		// Check to see if we received 'initialTab' as a prop. If so, we want to setSort()
+		// to filter comments based on that parameter. This allows us to set the comment
+		// sorting to the "You" tab when you leave a comment from an event item.
+		if (this.initialTab && !this.tabSet) {
+			this.setSort({ store: this.store, sort: this.initialTab });
+			this.tabSet = true;
 		}
 
 		try {

--- a/src/app/components/event-item/controls/comments/comments.ts
+++ b/src/app/components/event-item/controls/comments/comments.ts
@@ -3,6 +3,7 @@ import { Component, Prop, Watch } from 'vue-property-decorator';
 import { Analytics } from '../../../../../_common/analytics/analytics.service';
 import { AppAuthRequired } from '../../../../../_common/auth/auth-required-directive';
 import FormComment from '../../../../../_common/comment/add/add.vue';
+import { Comment } from '../../../../../_common/comment/comment-model';
 import {
 	CommentAction,
 	CommentMutation,
@@ -106,6 +107,7 @@ export default class AppEventItemControlsComments extends Vue {
 		CommentModal.show({
 			model: this.model,
 			displayMode: 'comments',
+			initialTab: Comment.SORT_YOU,
 		});
 	}
 


### PR DESCRIPTION
Created initialTab optional prop for comment modals. This will allow us to set the tab sorting to a value other than the default in the comments-store. It is now set to change the sorting to the "You" tab when a comment is created from an event-item.

Also changed how we update the comment-store when deleting your own comment; it should now update the count and totalCount when a comment is either created or deleted, making the counts a little more seamless.