### PR TITLE
Responsive-dimensions max-height based on screen height for mobile

### DIFF
--- a/src/app/components/activity/feed/devlog-post/media/item/item.ts
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.ts
@@ -48,8 +48,12 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 			return;
 		}
 
+		// If the screen size is considered mobile, we want to treat
+		// the mobile keyboard as if it doesn't exist. Using the
+		// 'window.screen.height' will let us get the height of
+		// the screen, rather than the viewport.
 		if (Screen.isMobile) {
-			return screen.height * 0.45;
+			return window.screen.height * 0.45;
 		}
 		return Screen.height * 0.45;
 	}

--- a/src/app/components/activity/feed/devlog-post/media/item/item.ts
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.ts
@@ -49,7 +49,7 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 		}
 
 		if (Screen.isMobile) {
-			return window.outerHeight * 0.45;
+			return screen.height * 0.45;
 		}
 		return Screen.height * 0.45;
 	}

--- a/src/app/components/activity/feed/devlog-post/media/item/item.ts
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.ts
@@ -43,6 +43,17 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 		return this.isActive;
 	}
 
+	get deviceMaxHeight() {
+		if (GJ_IS_SSR) {
+			return;
+		}
+
+		if (Screen.isMobile) {
+			return window.outerHeight * 0.45;
+		}
+		return Screen.height * 0.45;
+	}
+
 	async onDimensionsChange(e: AppResponsiveDimensionsChangeEvent) {
 		this.emitBootstrap();
 		this.isFilled = e.isFilled;

--- a/src/app/components/activity/feed/devlog-post/media/item/item.vue
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.vue
@@ -7,7 +7,7 @@
 			}"
 			:ratio="mediaItem.width / mediaItem.height"
 			:max-width="mediaItem.width"
-			:max-height="!GJ_IS_SSR ? Screen.height * 0.45 : undefined"
+			:max-height="deviceMaxHeight"
 			@change="onDimensionsChange"
 		>
 			<app-event-item-media-tags :gif="mediaItem.is_animated" />


### PR DESCRIPTION
responsive-dimensions will now check if the screen size is mobile and set the max-height based on the total screen height of the device. This will allow it to ignore resizing images when a keyboard is opened on mobile.