### PR TITLE
Media item avg_img_color set as background-color

### DIFF
--- a/src/_common/media-item/media-item-model.ts
+++ b/src/_common/media-item/media-item-model.ts
@@ -42,7 +42,7 @@ export class MediaItem extends Model {
 	mediaserver_url_webm!: string;
 	mediaserver_url_mp4!: string;
 	mediaserver_url!: string;
-	avg_img_color!: string;
+	avg_img_color!: null | string;
 	img_has_transparency!: boolean;
 
 	post_id?: number;

--- a/src/_common/media-item/media-item-model.ts
+++ b/src/_common/media-item/media-item-model.ts
@@ -42,6 +42,8 @@ export class MediaItem extends Model {
 	mediaserver_url_webm!: string;
 	mediaserver_url_mp4!: string;
 	mediaserver_url!: string;
+	avg_img_color!: string;
+	img_has_transparency!: boolean;
 
 	post_id?: number;
 

--- a/src/app/components/activity/feed/devlog-post/media/item/item.ts
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.ts
@@ -53,7 +53,7 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 			});
 		}
 
-		if (!this.mediaItem.img_has_transparency) {
+		if (this.mediaItem.avg_img_color && !this.mediaItem.img_has_transparency) {
 			Object.assign(style, {
 				backgroundColor: '#' + this.mediaItem.avg_img_color,
 			});

--- a/src/app/components/activity/feed/devlog-post/media/item/item.ts
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.ts
@@ -43,6 +43,25 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 		return this.isActive;
 	}
 
+	get itemStyling() {
+		let style = {};
+
+		if (!GJ_IS_SSR) {
+			Object.assign(style, {
+				maxWidth: this.mediaItem.width + 'px',
+				maxHeight: this.mediaItem.height + 'px',
+			});
+		}
+
+		if (!this.mediaItem.img_has_transparency) {
+			Object.assign(style, {
+				backgroundColor: '#' + this.mediaItem.avg_img_color,
+			});
+		}
+
+		return style;
+	}
+
 	get deviceMaxHeight() {
 		if (GJ_IS_SSR) {
 			return;

--- a/src/app/components/activity/feed/devlog-post/media/item/item.vue
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.vue
@@ -15,12 +15,7 @@
 			<app-img-responsive
 				v-if="!isPostHydrated || !mediaItem.is_animated"
 				class="-img"
-				:style="
-					!GJ_IS_SSR && {
-						maxWidth: mediaItem.width + 'px',
-						maxHeight: mediaItem.height + 'px',
-					}
-				"
+				:style="itemStyling"
 				:src="mediaItem.mediaserver_url"
 				alt=""
 				ondragstart="return false"
@@ -28,12 +23,7 @@
 			<app-video
 				v-else-if="shouldVideoPlay"
 				class="-video"
-				:style="
-					!GJ_IS_SSR && {
-						maxWidth: mediaItem.width + 'px',
-						maxHeight: mediaItem.height + 'px',
-					}
-				"
+				:style="itemStyling"
 				:poster="mediaItem.mediaserver_url"
 				:webm="mediaItem.mediaserver_url_webm"
 				:mp4="mediaItem.mediaserver_url_mp4"


### PR DESCRIPTION
Sets the background-color of a media item to the average color of the item if the item has no transparency.

Also changed some style bindings into computed getters for a cleaner template.