### PR TITLE
Add elevate-hover mixins

### DIFF
--- a/src/_common/game/thumbnail/thumbnail.styl
+++ b/src/_common/game/thumbnail/thumbnail.styl
@@ -11,8 +11,12 @@
 	@media $media-sm-up
 		margin-bottom: $grid-gutter-width
 
-		.-thumb
-			elevate-hover-2()
+		&:hover
+			.-thumb
+				elevate-2()
+
+.-thumb
+	elevate-0()
 
 .-controls
 	position: absolute

--- a/src/_common/game/thumbnail/thumbnail.styl
+++ b/src/_common/game/thumbnail/thumbnail.styl
@@ -11,12 +11,12 @@
 	@media $media-sm-up
 		margin-bottom: $grid-gutter-width
 
+		.-thumb
+			elevate-0()
+
 		&:hover
 			.-thumb
 				elevate-2()
-
-.-thumb
-	elevate-0()
 
 .-controls
 	position: absolute

--- a/src/_common/game/thumbnail/thumbnail.styl
+++ b/src/_common/game/thumbnail/thumbnail.styl
@@ -11,9 +11,8 @@
 	@media $media-sm-up
 		margin-bottom: $grid-gutter-width
 
-		&:hover
-			.-thumb
-				elevate-2()
+		.-thumb
+			elevate-hover-2()
 
 .-controls
 	position: absolute

--- a/src/_styles/common/mixins.styl
+++ b/src/_styles/common/mixins.styl
@@ -205,6 +205,31 @@ elevate-2()
 elevate-3()
 	elevate('24')
 
+// Hover animations
+elevate-hover-xs()
+	elevate-0()
+
+	&:hover
+		elevate('1')
+
+elevate-hover-1()
+	elevate-0()
+
+	&:hover
+		elevate('3')
+
+elevate-hover-2()
+	elevate-0()
+
+	&:hover
+		elevate('8')
+
+elevate-hover-3()
+	elevate-0()
+
+	&:hover
+		elevate('24')
+
 /**
  * Images
  */

--- a/src/_styles/common/mixins.styl
+++ b/src/_styles/common/mixins.styl
@@ -210,25 +210,25 @@ elevate-hover-xs()
 	elevate-0()
 
 	&:hover
-		elevate('1')
+		elevate-xs()
 
 elevate-hover-1()
 	elevate-0()
 
 	&:hover
-		elevate('3')
+		elevate-1()
 
 elevate-hover-2()
 	elevate-0()
 
 	&:hover
-		elevate('8')
+		elevate-2()
 
 elevate-hover-3()
 	elevate-0()
 
 	&:hover
-		elevate('24')
+		elevate-3()
 
 /**
  * Images

--- a/src/app/components/community/channel/card/card.styl
+++ b/src/app/components/community/channel/card/card.styl
@@ -3,6 +3,7 @@
 @require './variables'
 
 .community-channel-card
+	elevate-hover-1()
 	position: relative
 	display: block
 	flex-shrink: 0
@@ -16,7 +17,6 @@
 	margin-bottom: ($line-height-computed / 2)
 
 	&:hover
-		elevate-1()
 		theme-prop('border-color', 'link')
 
 		.-card-bg-img

--- a/src/app/components/game/community-badge/community-badge.styl
+++ b/src/app/components/game/community-badge/community-badge.styl
@@ -9,11 +9,9 @@
 	margin-bottom: $line-height-computed
 	overflow: hidden
 	padding: 10px 15px
-	elevate-0()
+	elevate-hover-2()
 
 	&:hover
-		elevate-2()
-
 		.-header
 			background-size: 105% auto
 			filter: blur(1px)

--- a/src/app/components/trophy/card/card.styl
+++ b/src/app/components/trophy/card/card.styl
@@ -5,13 +5,11 @@
 	position: relative
 
 .-trophy-card
+	elevate-hover-2()
 	height: 280px
 	position: relative
 	overflow: hidden
 	cursor: pointer
-
-	&:hover
-		elevate-2()
 
 .-trophy-new
 	border-color: var(--theme-notice)


### PR DESCRIPTION
Added new stylus mixins for when we use `elevate-'X'()` under a `&:hover` selector.

Use an `elevate-hover-'X'()` format on the element that you want to be hovered. The mixin will add the `&:hover` selector for you. This will give the element a transition for both entering and leaving hover.