### PR TITLE
New resize observer polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"prosemirror-view": "1.6.4",
 		"qs": "6.7.0",
 		"reflect-metadata": "0.1.12",
-		"resize-observer": "1.0.0",
+		"resize-observer-polyfill": "1.5.1",
 		"rxjs": "5.5.2",
 		"sanitize-html": "1.19.1",
 		"shell-escape": "0.2.0",

--- a/src/_common/content/components/gif/gif.ts
+++ b/src/_common/content/components/gif/gif.ts
@@ -1,4 +1,4 @@
-import { ResizeObserver } from 'resize-observer';
+import ResizeObserver from 'resize-observer-polyfill';
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';

--- a/src/_common/content/components/media-item/media-item.ts
+++ b/src/_common/content/components/media-item/media-item.ts
@@ -1,4 +1,4 @@
-import { ResizeObserver } from 'resize-observer';
+import ResizeObserver from 'resize-observer-polyfill';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import AppLoading from '../../../loading/loading.vue';

--- a/src/_common/content/content-editor/content-editor.ts
+++ b/src/_common/content/content-editor/content-editor.ts
@@ -2,7 +2,7 @@ import { DOMParser, Node } from 'prosemirror-model';
 import { EditorState, Plugin, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import 'prosemirror-view/style/prosemirror.css';
-import { ResizeObserver } from 'resize-observer';
+import ResizeObserver from 'resize-observer-polyfill';
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { ContentContext, ContextCapabilities } from '../content-context';

--- a/src/_common/form-vue/control/prefixed-input/prefixed-input.ts
+++ b/src/_common/form-vue/control/prefixed-input/prefixed-input.ts
@@ -1,4 +1,4 @@
-import { ResizeObserver } from 'resize-observer';
+import ResizeObserver from 'resize-observer-polyfill';
 import { createTextMaskInputElement } from 'text-mask-core/dist/textMaskCore';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { Ruler } from '../../../ruler/ruler-service';

--- a/src/_common/observe-dimensions/observe-dimensions.directive.ts
+++ b/src/_common/observe-dimensions/observe-dimensions.directive.ts
@@ -1,4 +1,4 @@
-import { ResizeObserver } from 'resize-observer';
+import ResizeObserver from 'resize-observer-polyfill';
 import { DirectiveOptions } from 'vue';
 
 const observers = new WeakMap<HTMLElement, ResizeObserver>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10061,15 +10061,15 @@ requires-port@1.x.x, requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resize-observer-polyfill@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
   integrity sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg==
-
-resize-observer@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/resize-observer/-/resize-observer-1.0.0.tgz#4f8380b73b411af4ed7d916fe85a2d59900e71ef"
-  integrity sha512-D7UFShDm2TgrEDEyeg+/tTEbvOgPWlvPAfJtxiKp+qutu6HowmcGJKjECgGru0PPDIj3SAucn3ZPpOx54fF7DQ==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Replace package from `https://www.npmjs.com/package/resize-observer` with `https://www.npmjs.com/package/resize-observer-polyfill`

The first package `resize-observer` does not actually polyfill only when required, but always overwrites the browser's implementation of ResizeObserver, if available.

The second package we will use with this PR will only kick in if the browser does not have a native implementation.
It also doesn't use polling, so should be more performant for the few browser engines that don't implement it natively.