### PR TITLE
Fix banned user page

### DIFF
--- a/src/app/views/profile/overview/feed/feed.ts
+++ b/src/app/views/profile/overview/feed/feed.ts
@@ -35,7 +35,11 @@ function getFetchUrl(route: Route) {
 	lazy: true,
 	deps: { query: ['tab', 'feed_last_id'] },
 	resolver: ({ route }) =>
-		Api.sendRequest(ActivityFeedService.makeFeedUrl(route, getFetchUrl(route))),
+		Api.sendRequest(ActivityFeedService.makeFeedUrl(route, getFetchUrl(route)), undefined, {
+			// Don't error redirect here. It would go to 404 if the user is banned, and prevent us
+			// from showing the "This user is banned" page.
+			noErrorRedirect: true,
+		}),
 })
 export default class RouteProfileOverviewFeed extends BaseRouteComponent {
 	@State

--- a/src/app/views/profile/overview/overview.ts
+++ b/src/app/views/profile/overview/overview.ts
@@ -400,4 +400,8 @@ export default class RouteProfileOverview extends BaseRouteComponent {
 	onClickTrophy(userTrophy: UserBaseTrophy) {
 		TrophyModal.show(userTrophy);
 	}
+
+	onClickUnfollow() {
+		this.user?.$unfollow();
+	}
 }

--- a/src/app/views/profile/overview/overview.vue
+++ b/src/app/views/profile/overview/overview.vue
@@ -24,7 +24,7 @@
 					</app-button>
 				</app-expand>
 
-				<app-expand :when="!user.is_following">
+				<app-expand :when="user.is_following">
 					<!-- Create some padding -->
 					<template v-if="isFriend"><br /><br /></template>
 

--- a/src/app/views/profile/overview/overview.vue
+++ b/src/app/views/profile/overview/overview.vue
@@ -5,22 +5,38 @@
 		-->
 		<section class="section fill-notice" v-if="!user.status">
 			<div class="container">
-				<p>
+				<h2 class="-banned-header">
 					<translate>profile.banned_message_html</translate>
-				</p>
+				</h2>
 
 				<app-expand :when="isFriend">
 					<p>
 						<strong><translate>This user was your friend.</translate></strong>
 						<br />
 						<translate>
-							If you remove them from your friends list, you will no longer be able to access your
-							chat history with them.
+							If you remove them from your friends list, you will no longer be able to
+							access your chat history with them.
 						</translate>
 					</p>
 
 					<app-button solid @click="removeFriend()">
 						<translate>profile.remove_friend_button</translate>
+					</app-button>
+				</app-expand>
+
+				<br /><br />
+
+				<app-expand :when="user.is_following">
+					<p>
+						<strong><translate>You were following this user.</translate></strong>
+						<br />
+						<translate>
+							If you unfollow them now, you won't be able to follow them again.
+						</translate>
+					</p>
+
+					<app-button solid @click="onClickUnfollow()">
+						<translate>Unfollow</translate>
 					</app-button>
 				</app-expand>
 			</div>
@@ -114,7 +130,12 @@
 							<app-button v-if="canAddAsFriend" block @click="sendFriendRequest()">
 								<translate>profile.friend_request_button</translate>
 							</app-button>
-							<app-button v-else-if="canMessage" block icon="user-messages" @click="openMessaging">
+							<app-button
+								v-else-if="canMessage"
+								block
+								icon="user-messages"
+								@click="openMessaging"
+							>
 								<translate>Message</translate>
 							</app-button>
 
@@ -130,7 +151,11 @@
 									{{ gamesCount | number }} Games
 								</app-button>
 
-								<app-button v-if="videosCount > 0" block :to="{ name: 'profile.videos' }">
+								<app-button
+									v-if="videosCount > 0"
+									block
+									:to="{ name: 'profile.videos' }"
+								>
 									{{ videosCount | number }} Videos
 								</app-button>
 							</template>
@@ -142,19 +167,28 @@
 						<template v-if="hasLinksSection">
 							<template v-if="linkedAccounts.length">
 								<div v-if="twitchAccount">
-									<app-link-external class="link-unstyled" :href="twitchAccount.platformLink">
+									<app-link-external
+										class="link-unstyled"
+										:href="twitchAccount.platformLink"
+									>
 										<app-jolticon :icon="twitchAccount.icon" />
 										{{ twitchAccount.name }}
 									</app-link-external>
 								</div>
 								<div v-if="mixerAccount">
-									<app-link-external class="link-unstyled" :href="mixerAccount.platformLink">
+									<app-link-external
+										class="link-unstyled"
+										:href="mixerAccount.platformLink"
+									>
 										<app-jolticon :icon="mixerAccount.icon" />
 										{{ mixerAccount.name }}
 									</app-link-external>
 								</div>
 								<div v-if="twitterAccount">
-									<app-link-external class="link-unstyled" :href="twitterAccount.platformLink">
+									<app-link-external
+										class="link-unstyled"
+										:href="twitterAccount.platformLink"
+									>
 										<app-jolticon :icon="twitterAccount.icon" />
 										<span>@</span>
 										{{ twitterAccount.name }}
@@ -170,7 +204,10 @@
 									</app-link-external>
 								</div>
 								<div v-if="googleAccount">
-									<app-link-external class="link-unstyled" :href="googleAccount.platformLink">
+									<app-link-external
+										class="link-unstyled"
+										:href="googleAccount.platformLink"
+									>
 										<app-jolticon :icon="googleAccount.icon" />
 										{{ googleAccount.name }}
 									</app-link-external>
@@ -186,7 +223,9 @@
 								<div v-for="channel of youtubeChannels" :key="channel.id">
 									<app-link-external
 										class="link-unstyled"
-										:href="`https://www.youtube.com/channel/${channel.channel_id}`"
+										:href="
+											`https://www.youtube.com/channel/${channel.channel_id}`
+										"
 									>
 										<app-jolticon icon="youtube" />
 										{{ channel.title }}
@@ -236,7 +275,10 @@
 										}"
 										v-app-tooltip.bottom="community.name"
 									>
-										<app-community-thumbnail-img class="-community-thumb" :community="community" />
+										<app-community-thumbnail-img
+											class="-community-thumb"
+											:community="community"
+										/>
 										<app-community-verified-tick
 											class="-community-verified-tick"
 											:community="community"
@@ -271,7 +313,11 @@
 							</div>
 
 							<app-game-list-placeholder v-if="!isOverviewLoaded" :num="7" />
-							<app-game-list v-else-if="games.length" :games="games" event-label="profile" />
+							<app-game-list
+								v-else-if="games.length"
+								:games="games"
+								event-label="profile"
+							/>
 						</template>
 
 						<!-- Trophies -->
@@ -312,7 +358,8 @@
 								<app-jolticon icon="notice" notice />
 								<b><translate>This user blocked you.</translate></b>
 								<translate>
-									You are unable to shout at them or comment on their posts and games.
+									You are unable to shout at them or comment on their posts and
+									games.
 								</translate>
 							</p>
 						</div>
@@ -327,7 +374,9 @@
 							<div class="alert">
 								<p>
 									<translate
-										:translate-params="{ username: '@' + userFriendship.target_user.username }"
+										:translate-params="{
+											username: '@' + userFriendship.target_user.username,
+										}"
 									>
 										Friend request to %{ username } pending acceptance.
 									</translate>
@@ -344,7 +393,11 @@
 						>
 							<div class="alert">
 								<p>
-									<translate :translate-params="{ username: '@' + userFriendship.user.username }">
+									<translate
+										:translate-params="{
+											username: '@' + userFriendship.user.username,
+										}"
+									>
 										%{ username } would like to be your friend.
 									</translate>
 								</p>
@@ -354,7 +407,9 @@
 								<app-button
 									trans
 									@click="rejectFriendRequest()"
-									v-app-tooltip="$gettext('profile.friend_request_decline_tooltip')"
+									v-app-tooltip="
+										$gettext('profile.friend_request_decline_tooltip')
+									"
 								>
 									<translate>profile.friend_request_decline</translate>
 								</app-button>
@@ -372,6 +427,9 @@
 <style lang="stylus" scoped>
 @require '~styles/variables'
 @require '~styles-lib/mixins'
+
+.-banned-header
+	margin-top: 0
 
 .-communities
 	display: grid
@@ -435,7 +493,6 @@
 	display: inline-block
 	position: relative
 	cursor: pointer
-
 </style>
 
 <script lang="ts" src="./overview"></script>

--- a/src/app/views/profile/overview/overview.vue
+++ b/src/app/views/profile/overview/overview.vue
@@ -24,9 +24,10 @@
 					</app-button>
 				</app-expand>
 
-				<br /><br />
+				<app-expand :when="!user.is_following">
+					<!-- Create some padding -->
+					<template v-if="isFriend"><br /><br /></template>
 
-				<app-expand :when="user.is_following">
 					<p>
 						<strong><translate>You were following this user.</translate></strong>
 						<br />

--- a/src/app/views/profile/profile.vue
+++ b/src/app/views/profile/profile.vue
@@ -4,7 +4,7 @@
 			If this user is banned, we show very little.
 		-->
 		<template v-if="!user.status">
-			<app-page-header v-if="!user.status">
+			<app-page-header>
 				<h1>
 					{{ user.display_name }}
 					<br />
@@ -48,7 +48,10 @@
 							<!-- Friend status -->
 							<span
 								class="tag tag-highlight"
-								v-if="userFriendship && userFriendship.state === UserFriendship.STATE_FRIENDS"
+								v-if="
+									userFriendship &&
+										userFriendship.state === UserFriendship.STATE_FRIENDS
+								"
 								v-app-tooltip="$gettext('profile.friend_tooltip')"
 							>
 								<translate>profile.friend_tag</translate>
@@ -99,7 +102,10 @@
 									</router-link>
 								</li>
 								<li>
-									<router-link :to="{ name: 'profile.following' }" active-class="active">
+									<router-link
+										:to="{ name: 'profile.following' }"
+										active-class="active"
+									>
 										<translate>Following</translate>
 										<span class="badge">
 											{{ user.following_count | number }}
@@ -107,7 +113,10 @@
 									</router-link>
 								</li>
 								<li>
-									<router-link :to="{ name: 'profile.followers' }" active-class="active">
+									<router-link
+										:to="{ name: 'profile.followers' }"
+										active-class="active"
+									>
 										<translate>Followers</translate>
 										<span class="badge">
 											{{ user.follower_count | number }}
@@ -126,17 +135,26 @@
 									</a>
 								</li>
 								<li v-if="videosCount > 0">
-									<router-link :to="{ name: 'profile.videos' }" active-class="active">
+									<router-link
+										:to="{ name: 'profile.videos' }"
+										active-class="active"
+									>
 										<translate>Videos</translate>
 									</router-link>
 								</li>
 								<li>
-									<router-link :to="{ name: 'profile.library' }" active-class="active">
+									<router-link
+										:to="{ name: 'profile.library' }"
+										active-class="active"
+									>
 										<translate>profile.library_tab</translate>
 									</router-link>
 								</li>
 								<li>
-									<router-link :to="{ name: 'profile.trophies' }" active-class="active">
+									<router-link
+										:to="{ name: 'profile.trophies' }"
+										active-class="active"
+									>
 										<translate>Trophies</translate>
 										<span class="badge">
 											{{ trophyCount | number }}
@@ -169,21 +187,29 @@
 											<a
 												class="list-group-item has-icon"
 												v-if="
-													userFriendship && userFriendship.state === UserFriendship.STATE_FRIENDS
+													userFriendship &&
+														userFriendship.state ===
+															UserFriendship.STATE_FRIENDS
 												"
 												@click="removeFriend()"
 											>
 												<app-jolticon icon="friend-remove-1" notice />
 												<translate>profile.remove_friend_button</translate>
 											</a>
-											<a class="list-group-item has-icon" v-if="canBlock" @click="blockUser">
+											<a
+												class="list-group-item has-icon"
+												v-if="canBlock"
+												@click="blockUser"
+											>
 												<app-jolticon icon="friend-remove-2" notice />
 												<translate>Block user</translate>
 											</a>
 											<a
 												class="list-group-item has-icon"
 												v-if="app.user && app.user.permission_level > 0"
-												:href="`${Environment.baseUrl}/moderate/users/view/${user.id}`"
+												:href="
+													`${Environment.baseUrl}/moderate/users/view/${user.id}`
+												"
 												target="_blank"
 											>
 												<app-jolticon icon="cog" />


### PR DESCRIPTION
When visiting a banned user, it currently shows a 404.

Introducing noErrorRedirect to a request that returns a 404 only for banned users allows the proper banned user view to show up again.

This also adds an unfollow button to the page which allows users to unfollow banned users.