### PR TITLE
Change transition on user-follow expanding div

### DIFF
--- a/src/app/components/event-item/controls/user-follow/user-follow.ts
+++ b/src/app/components/event-item/controls/user-follow/user-follow.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component, Emit, Prop } from 'vue-property-decorator';
 import { propOptional, propRequired } from '../../../../../utils/vue';
-import AppExpand from '../../../../../_common/expand/expand.vue';
 import { FiresidePost } from '../../../../../_common/fireside/post/post-model';
 import { Screen } from '../../../../../_common/screen/screen-service';
 import AppUserFollowWidget from '../../../../../_common/user/follow/widget.vue';
@@ -9,7 +8,6 @@ import AppUserFollowWidget from '../../../../../_common/user/follow/widget.vue';
 @Component({
 	components: {
 		AppUserFollowWidget,
-		AppExpand,
 	},
 })
 export default class AppEventItemControlsUserFollow extends Vue {

--- a/src/app/components/event-item/controls/user-follow/user-follow.vue
+++ b/src/app/components/event-item/controls/user-follow/user-follow.vue
@@ -1,6 +1,6 @@
 <template>
-	<app-expand :when="shouldShow" :animate-initial="false">
-		<div class="-user-follow alert">
+	<transition>
+		<div v-if="shouldShow" class="-user-follow anim-fade-enter alert">
 			<div class="-content">
 				<p class="-flex-auto small">
 					<translate>
@@ -20,7 +20,7 @@
 				<app-button class="-cancel" circle trans icon="remove" @click="emitClose()" />
 			</div>
 		</div>
-	</app-expand>
+	</transition>
 </template>
 
 <script lang="ts" src="./user-follow"></script>


### PR DESCRIPTION
Removed the AppExpand transition and replaced it with a vue transition to fade-in when activated.

This should make the component feel less laggy when it's opened a lot of times on one page.