### PR TITLE
Add AppImgBackdrop and wrap applicable elements

### DIFF
--- a/src/_common/content/components/media-item/media-item.ts
+++ b/src/_common/content/components/media-item/media-item.ts
@@ -1,6 +1,7 @@
 import { ResizeObserver } from 'resize-observer';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+import AppImgBackdrop from '../../../img/backdrop/backdrop.vue';
 import AppLoading from '../../../loading/loading.vue';
 import { MediaItem } from '../../../media-item/media-item-model';
 import { AppTooltip } from '../../../tooltip/tooltip';
@@ -12,6 +13,7 @@ import AppBaseContentComponent from '../base/base-content-component.vue';
 	components: {
 		AppBaseContentComponent,
 		AppLoading,
+		AppImgBackdrop,
 	},
 	directives: {
 		AppTooltip,

--- a/src/_common/content/components/media-item/media-item.vue
+++ b/src/_common/content/components/media-item/media-item.vue
@@ -30,13 +30,15 @@
 						rel="nofollow noopener"
 						target="_blank"
 					>
-						<img
-							class="img-responsive content-image"
-							:src="mediaItem.img_url"
-							:alt="title"
-							:title="title"
-							@load="onImageLoad"
-						/>
+						<app-img-backdrop :item="mediaItem">
+							<img
+								class="img-responsive content-image"
+								:src="mediaItem.img_url"
+								:alt="title"
+								:title="title"
+								@load="onImageLoad"
+							/>
+						</app-img-backdrop>
 					</component>
 				</template>
 				<template v-else-if="hasError">

--- a/src/_common/game/thumbnail-img/thumbnail-img.ts
+++ b/src/_common/game/thumbnail-img/thumbnail-img.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { ContentFocus } from '../../content-focus/content-focus.service';
+import AppImgBackdrop from '../../img/backdrop/backdrop.vue';
 import { AppImgResponsive } from '../../img/responsive/responsive';
 import { Screen } from '../../screen/screen-service';
 import AppVideo from '../../video/video.vue';
@@ -9,6 +10,7 @@ import { Game } from '../game.model';
 @Component({
 	components: {
 		AppImgResponsive,
+		AppImgBackdrop,
 		AppVideo,
 	},
 })

--- a/src/_common/game/thumbnail-img/thumbnail-img.vue
+++ b/src/_common/game/thumbnail-img/thumbnail-img.vue
@@ -6,25 +6,27 @@
 		}"
 	>
 		<div class="-inner">
-			<app-jolticon class="-icon" icon="game" />
+			<app-img-backdrop :item="mediaItem" radius="8px">
+				<app-jolticon class="-icon" icon="game" />
 
-			<div class="-media" v-if="mediaItem && !hideMedia">
-				<app-img-responsive
-					class="-img"
-					:src="mediaItem.mediaserver_url"
-					alt=""
-					@imgloadchange="imgLoadChange"
-				/>
+				<div class="-media" v-if="mediaItem && !hideMedia">
+					<app-img-responsive
+						class="-img"
+						:src="mediaItem.mediaserver_url"
+						alt=""
+						@imgloadchange="imgLoadChange"
+					/>
 
-				<app-video
-					v-if="hasVideo"
-					class="-video"
-					:poster="mediaItem.mediaserver_url"
-					:webm="mediaItem.mediaserver_url_webm"
-					:mp4="mediaItem.mediaserver_url_mp4"
-					:should-play="shouldPlayVideo"
-				/>
-			</div>
+					<app-video
+						v-if="hasVideo"
+						class="-video"
+						:poster="mediaItem.mediaserver_url"
+						:webm="mediaItem.mediaserver_url_webm"
+						:mp4="mediaItem.mediaserver_url_mp4"
+						:should-play="shouldPlayVideo"
+					/>
+				</div>
+			</app-img-backdrop>
 		</div>
 	</div>
 </template>

--- a/src/_common/img/backdrop/backdrop.ts
+++ b/src/_common/img/backdrop/backdrop.ts
@@ -14,13 +14,6 @@ export default class AppImgBackdrop extends Vue {
 	@Prop(propOptional(String))
 	radius?: string;
 
-	// @Prop(propOptional(Number))
-	// height?: number;
-
-	/* maybe for Community cards - they have a transparency filter */
-	// @Prop(propOptional(Boolean))
-	// trans?: boolean;
-
 	get _borderRadius() {
 		if (this.block) {
 			return;
@@ -34,26 +27,6 @@ export default class AppImgBackdrop extends Vue {
 		}
 	}
 
-	// get itemWidth() {
-	// 	if (this.mediaItem && this.mediaItem.width) {
-	// 		return this.mediaItem.width;
-	// 	}
-
-	// 	return;
-	// }
-
-	// get itemHeight() {
-	// 	if (this.mediaItem && this.mediaItem.height) {
-	// 		return this.mediaItem.height;
-	// 	}
-
-	// 	return;
-	// }
-
-	// get setHeight() {
-	// 	return this.height;
-	// }
-
 	get wrapperStyling() {
 		let style = {};
 
@@ -62,17 +35,6 @@ export default class AppImgBackdrop extends Vue {
 		if (!this.item) {
 			return style;
 		}
-
-		// Object.assign(style, {
-		// 	height: this.itemHeight,
-		// 	width: this.itemWidth,
-		// });
-
-		// if (this.setHeight) {
-		// 	Object.assign(style, {
-		// 		height: this.setHeight,
-		// 	});
-		// }
 
 		if (this.item.avg_img_color && !this.item.img_has_transparency) {
 			Object.assign(style, {

--- a/src/_common/img/backdrop/backdrop.ts
+++ b/src/_common/img/backdrop/backdrop.ts
@@ -1,0 +1,89 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { propOptional } from '../../../utils/vue';
+import { MediaItem } from '../../media-item/media-item-model';
+
+@Component({})
+export default class AppImgBackdrop extends Vue {
+	@Prop(propOptional(MediaItem))
+	item?: MediaItem;
+
+	@Prop(propOptional(Boolean))
+	block?: boolean;
+
+	@Prop(propOptional(String))
+	radius?: string;
+
+	// @Prop(propOptional(Number))
+	// height?: number;
+
+	/* maybe for Community cards - they have a transparency filter */
+	// @Prop(propOptional(Boolean))
+	// trans?: boolean;
+
+	get _borderRadius() {
+		if (this.block) {
+			return;
+		}
+
+		if (this.radius) {
+			return {
+				borderRadius: this.radius,
+				padding: '1px',
+			};
+		}
+	}
+
+	// get itemWidth() {
+	// 	if (this.mediaItem && this.mediaItem.width) {
+	// 		return this.mediaItem.width;
+	// 	}
+
+	// 	return;
+	// }
+
+	// get itemHeight() {
+	// 	if (this.mediaItem && this.mediaItem.height) {
+	// 		return this.mediaItem.height;
+	// 	}
+
+	// 	return;
+	// }
+
+	// get setHeight() {
+	// 	return this.height;
+	// }
+
+	get wrapperStyling() {
+		let style = {};
+
+		Object.assign(style, this._borderRadius);
+
+		if (!this.item) {
+			return style;
+		}
+
+		// Object.assign(style, {
+		// 	height: this.itemHeight,
+		// 	width: this.itemWidth,
+		// });
+
+		// if (this.setHeight) {
+		// 	Object.assign(style, {
+		// 		height: this.setHeight,
+		// 	});
+		// }
+
+		if (this.item.avg_img_color && !this.item.img_has_transparency) {
+			Object.assign(style, {
+				backgroundColor: '#' + this.item.avg_img_color,
+				/*	This might be needed for the Community sorting cards.
+				 *	We do a color/opacity filter on them, so it looks pretty
+				 * 	different if we don't change that somehow in this component. */
+				// opacity: this.trans ? 0.5 : 1,
+			});
+		}
+
+		return style;
+	}
+}

--- a/src/_common/img/backdrop/backdrop.vue
+++ b/src/_common/img/backdrop/backdrop.vue
@@ -1,0 +1,31 @@
+<template>
+	<div class="-app-img-backdrop">
+		<div class="-bg-color-styling" :style="wrapperStyling" />
+		<slot />
+	</div>
+</template>
+
+<style lang="stylus" scoped>
+.-app-img-backdrop
+	position: relative
+	width: inherit
+	height: 100%
+
+	img
+		position: relative
+
+.-bg-color-styling
+	position: absolute
+	width: 100%
+	height: 100%
+	background-color: white !important
+	// padding: 1px
+
+	// testing
+	border-radius: 0 !important
+	padding: 0 !important
+
+	background-clip: content-box
+</style>
+
+<script lang="ts" src="./backdrop"></script>

--- a/src/_common/img/backdrop/backdrop.vue
+++ b/src/_common/img/backdrop/backdrop.vue
@@ -18,13 +18,6 @@
 	position: absolute
 	width: 100%
 	height: 100%
-	background-color: white !important
-	// padding: 1px
-
-	// testing
-	border-radius: 0 !important
-	padding: 0 !important
-
 	background-clip: content-box
 </style>
 

--- a/src/_common/media-bar/item/item.ts
+++ b/src/_common/media-bar/item/item.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+import AppImgBackdrop from '../../img/backdrop/backdrop.vue';
 import { AppImgResponsive } from '../../img/responsive/responsive';
 
 export const MediaBarItemMaxHeight = 150;
@@ -7,6 +8,7 @@ export const MediaBarItemMaxHeight = 150;
 @Component({
 	components: {
 		AppImgResponsive,
+		AppImgBackdrop,
 	},
 })
 export default class AppMediaBarItem extends Vue {

--- a/src/_common/media-bar/item/item.vue
+++ b/src/_common/media-bar/item/item.vue
@@ -2,16 +2,16 @@
 	<div class="media-bar-item" :style="{ width, height }">
 		<a class="-wrapper">
 			<slot />
+			<app-img-backdrop :item="item.media_item" radius="8px">
+				<app-img-responsive
+					v-if="item.media_type !== 'sketchfab'"
+					:src="item.img_thumbnail"
+					:title="item.media_type == 'image' ? item.caption : item.title"
+					alt=""
+				/>
 
-			<app-img-responsive
-				v-if="item.media_type !== 'sketchfab'"
-				:src="item.img_thumbnail"
-				:title="item.media_type == 'image' ? item.caption : item.title"
-				alt=""
-			/>
-
-			<img v-else class="img-responsive" :src="item.img_thumbnail" alt="" />
-
+				<img v-else class="img-responsive" :src="item.img_thumbnail" alt="" />
+			</app-img-backdrop>
 			<span class="-play" v-if="item.media_type === 'video'">
 				<app-jolticon icon="play" />
 			</span>

--- a/src/_common/media-bar/lightbox/item/item.ts
+++ b/src/_common/media-bar/lightbox/item/item.ts
@@ -2,6 +2,7 @@ import { Subscription } from 'rxjs/Subscription';
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { findRequiredVueParent } from '../../../../utils/vue';
+import AppImgBackdrop from '../../../img/backdrop/backdrop.vue';
 import { AppImgResponsive } from '../../../img/responsive/responsive';
 import { Screen } from '../../../screen/screen-service';
 import AppSketchfabEmbed from '../../../sketchfab/embed/embed.vue';
@@ -14,6 +15,7 @@ import AppMediaBarLightbox from '../lightbox.vue';
 		AppVideoEmbed,
 		AppSketchfabEmbed,
 		AppImgResponsive,
+		AppImgBackdrop,
 	},
 })
 export default class AppMediaBarLightboxItem extends Vue {

--- a/src/_common/media-bar/lightbox/item/item.vue
+++ b/src/_common/media-bar/lightbox/item/item.vue
@@ -7,14 +7,25 @@
 					<!--
 					The min/max will be the actual dimensions for the image thumbnail.
 				-->
-					<app-img-responsive
-						:src="item.img_thumbnail"
-						:alt="item.caption"
+					<app-img-backdrop
+						:item="item.media_item"
 						:style="{
 							width: maxWidth ? maxWidth + 'px' : undefined,
 							height: maxHeight ? maxHeight + 'px' : undefined,
+							marginLeft: 'auto',
+							marginRight: 'auto',
 						}"
-					/>
+						radius="8px"
+					>
+						<app-img-responsive
+							:src="item.img_thumbnail"
+							:alt="item.caption"
+							:style="{
+								width: 'inherit',
+								height: 'inherit',
+							}"
+						/>
+					</app-img-backdrop>
 				</div>
 
 				<div class="-caption" v-if="item.caption" ref="caption">

--- a/src/_common/media-item/cover/cover.ts
+++ b/src/_common/media-item/cover/cover.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
+import AppImgBackdrop from '../../img/backdrop/backdrop.vue';
 import { AppImgResponsive } from '../../img/responsive/responsive';
 import { Ruler } from '../../ruler/ruler-service';
 import { Screen } from '../../screen/screen-service';
@@ -10,6 +11,7 @@ const ResizeSensor = require('css-element-queries/src/ResizeSensor');
 @Component({
 	components: {
 		AppImgResponsive,
+		AppImgBackdrop,
 	},
 })
 export default class AppMediaItemCover extends Vue {

--- a/src/_common/media-item/cover/cover.vue
+++ b/src/_common/media-item/cover/cover.vue
@@ -2,12 +2,14 @@
 	<div class="media-item-cover-container" :class="{ '-blur': blur }" :style="{ height }">
 		<section class="section media-item-cover" :class="{ loaded: isLoaded }">
 			<div class="media-item-cover-img">
-				<app-img-responsive
-					v-show="isLoaded"
-					:src="mediaItem.mediaserver_url"
-					@imgloadchange="onLoadChange"
-					alt=""
-				/>
+				<app-img-backdrop :item="mediaItem" :style="{ height }" block>
+					<app-img-responsive
+						v-show="isLoaded"
+						:src="mediaItem.mediaserver_url"
+						@imgloadchange="onLoadChange"
+						alt=""
+					/>
+				</app-img-backdrop>
 			</div>
 
 			<div class="media-item-cover-content">
@@ -47,7 +49,7 @@
 
 		img
 			width: 100%
-			height: auto
+			height: 100%
 
 .-blur
 	img

--- a/src/app/components/activity/feed/devlog-post/media/item/item.ts
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { Component, Emit, Inject, Prop } from 'vue-property-decorator';
+import AppImgBackdrop from '../../../../../../../_common/img/backdrop/backdrop.vue';
 import { AppImgResponsive } from '../../../../../../../_common/img/responsive/responsive';
 import { MediaItem } from '../../../../../../../_common/media-item/media-item-model';
 import {
@@ -14,6 +15,7 @@ import { ActivityFeedView } from '../../../view';
 @Component({
 	components: {
 		AppImgResponsive,
+		AppImgBackdrop,
 		AppVideo,
 		AppResponsiveDimensions,
 		AppEventItemMediaTags,
@@ -33,6 +35,8 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 	isActive!: boolean;
 
 	isFilled = false;
+	scaledWidth = 0;
+	scaledHeight = 0;
 
 	readonly Screen = Screen;
 
@@ -41,6 +45,14 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 
 	get shouldVideoPlay() {
 		return this.isActive;
+	}
+
+	get width() {
+		return this.scaledWidth + 'px';
+	}
+
+	get height() {
+		return this.scaledHeight + 'px';
 	}
 
 	get itemStyling() {
@@ -53,9 +65,10 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 			});
 		}
 
-		if (this.mediaItem.avg_img_color && !this.mediaItem.img_has_transparency) {
+		if (this.width && this.height) {
 			Object.assign(style, {
-				backgroundColor: '#' + this.mediaItem.avg_img_color,
+				width: this.width,
+				height: this.height,
 			});
 		}
 
@@ -80,5 +93,8 @@ export default class AppActivityFeedDevlogPostMediaItem extends Vue {
 	async onDimensionsChange(e: AppResponsiveDimensionsChangeEvent) {
 		this.emitBootstrap();
 		this.isFilled = e.isFilled;
+
+		this.scaledWidth = e.containerWidth;
+		this.scaledHeight = e.height;
 	}
 }

--- a/src/app/components/activity/feed/devlog-post/media/item/item.vue
+++ b/src/app/components/activity/feed/devlog-post/media/item/item.vue
@@ -11,24 +11,25 @@
 			@change="onDimensionsChange"
 		>
 			<app-event-item-media-tags :gif="mediaItem.is_animated" />
-
-			<app-img-responsive
-				v-if="!isPostHydrated || !mediaItem.is_animated"
-				class="-img"
-				:style="itemStyling"
-				:src="mediaItem.mediaserver_url"
-				alt=""
-				ondragstart="return false"
-			/>
-			<app-video
-				v-else-if="shouldVideoPlay"
-				class="-video"
-				:style="itemStyling"
-				:poster="mediaItem.mediaserver_url"
-				:webm="mediaItem.mediaserver_url_webm"
-				:mp4="mediaItem.mediaserver_url_mp4"
-				show-loading
-			/>
+			<app-img-backdrop :item="mediaItem" :block="isFilled" radius="8px">
+				<app-img-responsive
+					v-if="!isPostHydrated || !mediaItem.is_animated"
+					class="-img"
+					:style="itemStyling"
+					:src="mediaItem.mediaserver_url"
+					alt=""
+					ondragstart="return false"
+				/>
+				<app-video
+					v-else-if="shouldVideoPlay"
+					class="-video"
+					:style="itemStyling"
+					:poster="mediaItem.mediaserver_url"
+					:webm="mediaItem.mediaserver_url_webm"
+					:mp4="mediaItem.mediaserver_url_mp4"
+					show-loading
+				/>
+			</app-img-backdrop>
 		</app-responsive-dimensions>
 	</div>
 </template>

--- a/src/app/components/community/channel/card/card.ts
+++ b/src/app/components/community/channel/card/card.ts
@@ -2,10 +2,14 @@ import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { propOptional, propRequired } from '../../../../../utils/vue';
 import { Community } from '../../../../../_common/community/community.model';
+import AppImgBackdrop from '../../../../../_common/img/backdrop/backdrop.vue';
 import { MediaItem } from '../../../../../_common/media-item/media-item-model';
 import { AppTooltip } from '../../../../../_common/tooltip/tooltip';
 
 @Component({
+	components: {
+		AppImgBackdrop,
+	},
 	directives: {
 		AppTooltip,
 	},

--- a/src/app/components/community/channel/card/card.vue
+++ b/src/app/components/community/channel/card/card.vue
@@ -6,12 +6,14 @@
 		:title="label"
 	>
 		<div class="-card-bg" v-if="backgroundItem">
-			<div
-				class="-card-bg-img"
-				:style="{
-					'background-image': `url('${backgroundItem.mediaserver_url}')`,
-				}"
-			/>
+			<app-img-backdrop :item="backgroundItem" radius="8px" trans>
+				<div
+					class="-card-bg-img"
+					:style="{
+						'background-image': `url('${backgroundItem.mediaserver_url}')`,
+					}"
+				/>
+			</app-img-backdrop>
 		</div>
 
 		<div class="-card-content">

--- a/src/app/components/game/community-badge/community-badge.ts
+++ b/src/app/components/game/community-badge/community-badge.ts
@@ -1,13 +1,15 @@
-import { Community } from '../../../../_common/community/community.model';
-import { AppTheme } from '../../../../_common/theme/theme';
-import { number } from '../../../../_common/filters/number';
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
+import { Community } from '../../../../_common/community/community.model';
+import { number } from '../../../../_common/filters/number';
+import AppImgBackdrop from '../../../../_common/img/backdrop/backdrop.vue';
+import { AppTheme } from '../../../../_common/theme/theme';
 
 @Component({
 	components: {
 		AppTheme,
+		AppImgBackdrop,
 	},
 })
 export default class AppGameCommunityBadge extends Vue {

--- a/src/app/components/game/community-badge/community-badge.vue
+++ b/src/app/components/game/community-badge/community-badge.vue
@@ -7,15 +7,18 @@
 			}"
 		>
 			<div class="-community-container fill-darkest">
-				<div
-					v-if="community.header"
-					class="-header"
-					:style="{
-						'background-image': 'url(' + community.header.mediaserver_url + ')',
-					}"
-				>
-					<div class="-header-gradient" />
-				</div>
+				<app-img-backdrop :item="community.header" radius="8px">
+					<div
+						v-if="community.header"
+						class="-header"
+						:style="{
+							'background-image': 'url(' + community.header.mediaserver_url + ')',
+						}"
+					>
+						<div class="-header-gradient" />
+					</div>
+				</app-img-backdrop>
+
 				<div class="-content">
 					<div class="-thumbnail">
 						<img :src="community.img_thumbnail" />


### PR DESCRIPTION
Adding `AppImgBackdrop` as a common component. This allows us to wrap an image/fill its container to display the average color of the image while it's loading.

Passable props are:

- `item` as a MediaItem to get the `avg_img_color` value from it to display behind the image.
- `block` 