### PR TITLE
Fix post gif disappearing

### DIFF
--- a/src/app/components/activity/feed/devlog-post/media/media.ts
+++ b/src/app/components/activity/feed/devlog-post/media/media.ts
@@ -1,8 +1,8 @@
+import Vue from 'vue';
+import { Component, Inject, Prop } from 'vue-property-decorator';
 import { FiresidePost } from '../../../../../../_common/fireside/post/post-model';
 import { MediaItem } from '../../../../../../_common/media-item/media-item-model';
 import { Screen } from '../../../../../../_common/screen/screen-service';
-import Vue from 'vue';
-import { Component, Inject, Prop } from 'vue-property-decorator';
 import AppEventItemMediaIndicator from '../../../../event-item/media-indicator/media-indicator.vue';
 import { ActivityFeedItem } from '../../item-service';
 import { ActivityFeedView } from '../../view';
@@ -112,5 +112,9 @@ export default class AppActivityFeedDevlogPostMedia extends Vue {
 		}
 
 		this._updateSliderOffset();
+	}
+
+	getIsActiveMediaItem(item: MediaItem) {
+		return this.activeMediaItem?.id === item.id;
 	}
 }

--- a/src/app/components/activity/feed/devlog-post/media/media.vue
+++ b/src/app/components/activity/feed/devlog-post/media/media.vue
@@ -14,7 +14,7 @@
 						:key="mediaItem.id"
 						:media-item="mediaItem"
 						:is-post-hydrated="isHydrated"
-						:is-active="mediaItem === activeMediaItem"
+						:is-active="getIsActiveMediaItem(mediaItem)"
 						@bootstrap="onItemBootstrapped()"
 					/>
 				</div>


### PR DESCRIPTION
When recreating a post instance, media items on that post are also recreated.
The media slider on posts used to compare media item instances to determine active item, which ceases to work when the post gets recreated.
Now it uses media item ids instead.