### PR TITLE
Fix fade-collapse trying to expand posts by 0px

### DIFF
--- a/src/_common/fade-collapse/fade-collapse.ts
+++ b/src/_common/fade-collapse/fade-collapse.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { Component, Emit, Prop, Watch } from 'vue-property-decorator';
+import { sleep } from '../../utils/utils';
 import { Screen } from '../screen/screen-service';
 import { Scroll } from '../scroll/scroll.service';
 
@@ -39,8 +40,8 @@ export default class AppFadeCollapse extends Vue {
 	emitExpand(_e: Event) {}
 
 	async mounted() {
-		// Let it compile DOM.
-		await this.$nextTick();
+		// Let it compile DOM and wait for any images to be resized.
+		await sleep(0);
 
 		// Take threshold into account only if our collapse height is big enough
 		// for threshold to matter.


### PR DESCRIPTION
Changed `await this.$nextTick()` to `await sleep(0)`.

`nextTick()` was letting everything compile in the DOM but it was doing height calculations before any images were resized, making the component think it's taller that it really displays, and causing situations where it would let us expand within our specified `collapseHeight` and set `Threshhold`.