### PR TITLE
Fix controls shifting when a post is liked

### DIFF
--- a/src/_common/comment/video/like-widget/like-widget.vue
+++ b/src/_common/comment/video/like-widget/like-widget.vue
@@ -1,6 +1,7 @@
 <template>
 	<span v-app-auth-required>
 		<app-button
+			class="-like-button"
 			icon="heart"
 			circle
 			:trans="trans"
@@ -21,3 +22,9 @@
 </template>
 
 <script lang="ts" src="./like-widget"></script>
+
+<style lang="stylus" scoped>
+.-like-button
+	width: 36px
+	height: 36px
+</style>

--- a/src/_common/fireside/post/like/widget/widget.vue
+++ b/src/_common/fireside/post/like/widget/widget.vue
@@ -2,6 +2,7 @@
 	<span class="fireside-post-like-widget">
 		<span class="-like">
 			<app-button
+				class="-like-button"
 				icon="heart"
 				circle
 				:trans="trans"
@@ -31,6 +32,10 @@
 <style lang="stylus" scoped>
 .-like
 	position: relative
+
+	&-button
+		width: 36px
+		height: 36px
 
 .-like-anim-container
 	position: absolute


### PR DESCRIPTION
Set width and height to 36px for `FiresidePostLikeWidget` and `CommentVideoLikeWidget`. This fixes height issues from pixel rounding for borders, and scaling of line height when zooming in or out.