### PR TITLE
Fix wrapping of AppTimeAgo in mobile comment view

### DIFF
--- a/src/_common/message-thread/item/item.vue
+++ b/src/_common/message-thread/item/item.vue
@@ -90,9 +90,11 @@
 	margin-bottom: 1em
 
 .-byline
-	text-overflow()
+	display: flex
+	justify-content: space-between
 
 .-author
+	text-overflow()
 	margin-right: 2px
 
 	a
@@ -106,7 +108,7 @@
 		margin-right: 5px
 
 .-meta-slot
-	float: right
+	display: inline-flex
 	margin-left: 5px
 
 	>>> .tag

--- a/src/_common/message-thread/item/item.vue
+++ b/src/_common/message-thread/item/item.vue
@@ -16,11 +16,6 @@
 
 				<div class="timeline-list-item-details">
 					<div class="-meta clearfix" v-if="user">
-						<span class="-meta-slot">
-							<slot name="tags" />
-							<slot name="meta" />
-						</span>
-
 						<div class="-byline">
 							<span class="-author">
 								<router-link
@@ -54,6 +49,11 @@
 									<span class="text-muted">@{{ repliedTo.username }}</span>
 								</span>
 							</template>
+
+							<span class="-meta-slot">
+								<slot name="tags" />
+								<slot name="meta" />
+							</span>
 
 							<slot name="authors" />
 						</div>


### PR DESCRIPTION
Moved the meta slots into the -byline class that holds the author name, and changed styling to prevent wrapping of meta slot items.