### PR TITLE
Add text-overflow() to '@username' for forum topic author

### DIFF
--- a/src/app/components/forum/topic-list/topic-list.styl
+++ b/src/app/components/forum/topic-list/topic-list.styl
@@ -29,7 +29,7 @@
 			width: 40px
 
 		&-info
-			div
+			> div
 				text-overflow()
 
 			&-username

--- a/src/app/components/forum/topic-list/topic-list.styl
+++ b/src/app/components/forum/topic-list/topic-list.styl
@@ -29,8 +29,10 @@
 			width: 40px
 
 		&-info
-			&-username
+			div
 				text-overflow()
+
+			&-username
 				font-weight: bold
 
 .-vote


### PR DESCRIPTION
Added text-overflow() to both parts of the username where we show who made a forum topic.