### PR TITLE
Change new sticker notification blips to match style of communities

### DIFF
--- a/src/app/components/shell/account-popover/account-popover.vue
+++ b/src/app/components/shell/account-popover/account-popover.vue
@@ -228,8 +228,8 @@
 		border-style: solid
 
 	&-list
-		display: inline-block
-		margin-left: 8px
+		float: right
+		margin-top: 4px
 </style>
 
 <script lang="ts" src="./account-popover"></script>

--- a/src/app/components/shell/account-popover/account-popover.vue
+++ b/src/app/components/shell/account-popover/account-popover.vue
@@ -52,8 +52,8 @@
 						:to="{ name: 'dash.stickers.overview' }"
 						v-app-track-event="`account-popover:stickers`"
 					>
-						<span v-if="shouldShowNewStickers" class="-new-tag -new-tag-list"></span>
 						<translate>Stickers</translate>
+						<span v-if="shouldShowNewStickers" class="-new-tag -new-tag-list"></span>
 					</router-link>
 					<a
 						class="list-group-item offline-disable"
@@ -220,13 +220,16 @@
 
 	&-account
 		position: absolute
-		top: 4px
-		right: 4px
+		bottom: 8px
+		right: 8px
 		display: block
+		border-color: var(--theme-darkest)
+		border-width: 2px
+		border-style: solid
 
 	&-list
 		display: inline-block
-		margin-right: 8px
+		margin-left: 8px
 </style>
 
 <script lang="ts" src="./account-popover"></script>


### PR DESCRIPTION
Changed new sticker notification styling.
- blip on profile thumbnail in nav mimics styling of the community feature-counter.
- moved blip in popover from the left of "Stickers" to `float: right`, added some `margin-top` to center it.

![image](https://user-images.githubusercontent.com/2914500/80249904-b0c5bf80-8640-11ea-8f48-83364383dacb.png)
