### PR TITLE
Fix spacing of sticker collection cards

### DIFF
--- a/src/_common/sticker/card/card.vue
+++ b/src/_common/sticker/card/card.vue
@@ -19,10 +19,11 @@
 <style lang="stylus" scoped>
 @require '~styles/variables'
 @require '~styles-lib/mixins'
+@require './variables'
 
 .-card
 	change-bg('bg-offset')
-	width: 150px
+	width: $card-width
 	rounded-corners-lg()
 	position: relative
 	overflow: hidden

--- a/src/_common/sticker/card/variables.styl
+++ b/src/_common/sticker/card/variables.styl
@@ -1,0 +1,2 @@
+$card-width = 150px
+$card-margin = 8px

--- a/src/app/views/dashboard/stickers/overview/overview.vue
+++ b/src/app/views/dashboard/stickers/overview/overview.vue
@@ -51,11 +51,7 @@
 </template>
 
 <style lang="stylus" scoped>
-// @require 'src/_common/sticker/card/variables'
 @require '../../../../../_common/sticker/card/variables'
-
-// $-card-width = 150px
-// $-card-margin = 8px
 
 .-progress
 	max-width: 350px

--- a/src/app/views/dashboard/stickers/overview/overview.vue
+++ b/src/app/views/dashboard/stickers/overview/overview.vue
@@ -51,16 +51,20 @@
 </template>
 
 <style lang="stylus" scoped>
+// @require 'src/_common/sticker/card/variables'
+@require '../../../../../_common/sticker/card/variables'
+
+// $-card-width = 150px
+// $-card-margin = 8px
+
 .-progress
 	max-width: 350px
 
 .-collection
-	display: flex
-	flex-wrap: wrap
+	display: grid
+	grid-template-columns: repeat(auto-fill, $card-width)
 	justify-content: space-between
-
-	& > div
-		margin: 8px
+	grid-gap: $card-margin * 2
 </style>
 
 <script lang="ts" src="./overview"></script>


### PR DESCRIPTION
Change sticker display from `flex` to `grid`, fixing issues like this: 
![image](https://user-images.githubusercontent.com/2914500/80272932-da600480-869b-11ea-882a-33c95e75a963.png)
