### PR TITLE
Remove outline from popper on focus

### DIFF
--- a/src/_common/popper/popper.styl
+++ b/src/_common/popper/popper.styl
@@ -17,6 +17,7 @@ $-transition-time = 200ms
 .popper
 	display: block !important
 	z-index: $zindex-popover
+	outline: 0
 
 	// We don't want to show the popover stuff at all on SSR, or it breaks
 	// styling since it tries to fit the container into the page.


### PR DESCRIPTION
`outline: 0`