### PR TITLE
Use larger dimension for img-responsive

### DIFF
--- a/src/_common/img/responsive/responsive.ts
+++ b/src/_common/img/responsive/responsive.ts
@@ -62,7 +62,7 @@ export class AppImgResponsive extends Vue {
 		// Update width in the URL.
 		// We keep width within 100px increment bounds.
 		let newSrc = this.src;
-		let largerDimension = containerWidth > containerHeight ? containerWidth : containerHeight;
+		let largerDimension = Math.max(containerWidth, containerHeight);
 
 		if (Screen.isHiDpi) {
 			// For high dpi, double the width.

--- a/src/_common/img/responsive/responsive.ts
+++ b/src/_common/img/responsive/responsive.ts
@@ -51,29 +51,31 @@ export class AppImgResponsive extends Vue {
 
 	private async updateSrc() {
 		const containerWidth = Ruler.width(this.$el.parentNode as HTMLElement);
+		const containerHeight = Ruler.height(this.$el.parentNode as HTMLElement);
 
 		// Make sure we never do a 0 width, just in case.
 		// Seems to happen in some situations.
-		if (containerWidth <= 0) {
+		if (containerWidth <= 0 || containerHeight <= 0) {
 			return;
 		}
 
 		// Update width in the URL.
 		// We keep width within 100px increment bounds.
 		let newSrc = this.src;
-		let mediaserverWidth = containerWidth;
+		let largerDimension = containerWidth > containerHeight ? containerWidth : containerHeight;
+
 		if (Screen.isHiDpi) {
 			// For high dpi, double the width.
-			mediaserverWidth = mediaserverWidth * 2;
-			mediaserverWidth = Math.ceil(mediaserverWidth / 100) * 100;
+			largerDimension = largerDimension * 2;
+			largerDimension = Math.ceil(largerDimension / 100) * 100;
 		} else {
-			mediaserverWidth = Math.ceil(mediaserverWidth / 100) * 100;
+			largerDimension = Math.ceil(largerDimension / 100) * 100;
 		}
 
 		if (newSrc.search(WIDTH_HEIGHT_REGEX) !== -1) {
-			newSrc = newSrc.replace(WIDTH_HEIGHT_REGEX, '/' + mediaserverWidth + 'x2000/');
+			newSrc = newSrc.replace(WIDTH_HEIGHT_REGEX, '/' + largerDimension + 'x2000/');
 		} else {
-			newSrc = newSrc.replace(WIDTH_REGEX, '/' + mediaserverWidth + '/');
+			newSrc = newSrc.replace(WIDTH_REGEX, '/' + largerDimension + '/');
 		}
 
 		// Only if the src changed from previous runs.


### PR DESCRIPTION
img-responsive needs to get the larger value between height and width to work properly for tall/narrow images.

If we only go based off the container width, we can have issues with tall images where the image doesn't take up all of the container width and it ends up getting scaled up - making the image look blurry and low-quality.