### PR TITLE
Fix gifs turning into img tags on post view

### DIFF
--- a/src/_common/media-item/post/post.ts
+++ b/src/_common/media-item/post/post.ts
@@ -25,7 +25,7 @@ export default class AppMediaItemPost extends Vue {
 	@Prop(propRequired(MediaItem))
 	mediaItem!: MediaItem;
 
-	@Prop(propOptional(Boolean))
+	@Prop(propOptional(Boolean, true))
 	isPostHydrated?: boolean;
 
 	@Prop(propOptional(Boolean))


### PR DESCRIPTION
Added a default value of `true` for the `isPostHydrated` prop.

Post view didn't have both this prop and checks for img or video tags before making posts into a reusable component, so giving `isPostHydrated` a default value of `true` will allow video tags to appear again.