### PR TITLE
Fix cbar popper triggers from being misaligned

### DIFF
--- a/src/app/components/shell/cbar/item/item.styl
+++ b/src/app/components/shell/cbar/item/item.styl
@@ -64,6 +64,7 @@ $-bubble-size = 14px
 	position: absolute
 	width: 100%
 	height: 100%
+	top: 0
 
 	>>> > .trigger
 		width: 100%


### PR DESCRIPTION
Added `top: 0` to the cbar popper styling to align the right-click triggers to their respective communities.