### PR TITLE
Add default width and rounded corners for webkit scrollbars

### DIFF
--- a/src/_common/scroll/scroller/scroller.vue
+++ b/src/_common/scroll/scroller/scroller.vue
@@ -18,12 +18,12 @@
 @require '~styles-lib/mixins'
 
 // 6px appears to be the width for the 'thin' scrollbar on Firefox
-$-scrollbar-size = 6px
-$-thumb-radius = $-scrollbar-size / 2
-$-default-thumb = var(--theme-light)
-$-default-track = transparent
-$-modal-thumb = var(--dark-theme-bg-subtle)
-$-modal-track = var(--theme-bg)
+$-size-thick = 10px
+$-size-thin = 6px
+$-thumb-default = var(--theme-light)
+$-track-default = transparent
+$-thumb-modal = var(--dark-theme-bg-subtle)
+$-track-modal = var(--theme-bg)
 
 .scroll-scroller
 	scrollable()
@@ -41,34 +41,37 @@ $-modal-track = var(--theme-bg)
 
 	/* mouse, touch pad, and stylus-based screens */
 	@media (pointer: fine)
-		scrollbar-color: $-default-thumb $-default-track
+		scrollbar-color: $-thumb-default $-track-default
 
 		&::-webkit-scrollbar
-			background-color: $-default-track
+			background-color: $-track-default
+			width: $-size-thick
+			height: $-size-thick
 
 			&-thumb
-				background-color: $-default-thumb
+				background-color: $-thumb-default
+				border-radius: $-size-thick
 
 		&.-thin
 			scrollbar-width: thin
 
 			&::-webkit-scrollbar
-				width: $-scrollbar-size
-				height: $-scrollbar-size
+				width: $-size-thin
+				height: $-size-thin
 
 				&-thumb
-					border-radius: $-thumb-radius
+					border-radius: $-size-thin
 
 		// Override colors so transparency doesn't look weird
 		// with body background or others in full-screen modals.
 		&.modal
-			scrollbar-color: $-modal-thumb $-modal-track
+			scrollbar-color: $-thumb-modal $-track-modal
 
 			&::-webkit-scrollbar
-				background-color: $-modal-track
+				background-color: $-track-modal
 
 				&-thumb
-					background-color: $-modal-thumb
+					background-color: $-thumb-modal
 </style>
 
 <script lang="ts" src="./scroller"></script>

--- a/src/_common/scroll/scroller/scroller.vue
+++ b/src/_common/scroll/scroller/scroller.vue
@@ -18,7 +18,7 @@
 @require '~styles-lib/mixins'
 
 // 6px appears to be the width for the 'thin' scrollbar on Firefox
-$-size-thick = 10px
+$-size-default = 10px
 $-size-thin = 6px
 $-thumb-default = var(--theme-light)
 $-track-default = transparent
@@ -45,12 +45,12 @@ $-track-modal = var(--theme-bg)
 
 		&::-webkit-scrollbar
 			background-color: $-track-default
-			width: $-size-thick
-			height: $-size-thick
+			width: $-size-default
+			height: $-size-default
 
 			&-thumb
 				background-color: $-thumb-default
-				border-radius: $-size-thick
+				border-radius: $-size-default
 
 		&.-thin
 			scrollbar-width: thin

--- a/src/app/views/communities/view/overview/_nav/nav.styl
+++ b/src/app/views/communities/view/overview/_nav/nav.styl
@@ -16,7 +16,7 @@
 	@media $media-mobile
 		margin-bottom: 8px
 
-	div
+	.-inner
 		@media $media-lg-up
 			display: flex
 			flex-direction: column

--- a/src/app/views/communities/view/overview/_nav/nav.styl
+++ b/src/app/views/communities/view/overview/_nav/nav.styl
@@ -3,6 +3,10 @@
 @require '../../../../../components/community/channel/card/variables'
 
 .scroll-scroller
+	// bleed left
+	@media $media-lg-up
+		margin-left: -($grid-gutter-width / 2)
+
 	// The nav shifts to the right side of the screen on MD size specifially.
 	// Add some spacing between the content below, and allow content to bleed-right.
 	@media $media-md
@@ -12,9 +16,7 @@
 	@media $media-mobile
 		margin-bottom: 8px
 
-	// We need to target the AppScrollInviewParent child of
-	// AppScrollScroller to make sure things are displaying properly.
-	>>> > div
+	div
 		@media $media-lg-up
 			display: flex
 			flex-direction: column

--- a/src/app/views/communities/view/overview/_nav/nav.styl
+++ b/src/app/views/communities/view/overview/_nav/nav.styl
@@ -2,25 +2,30 @@
 @require '~styles-lib/mixins'
 @require '../../../../../components/community/channel/card/variables'
 
-nav
-	@media $media-lg-up
-		display: flex
-		flex-direction: column
-		align-items: flex-end
-
-	// The nav shifts to the right side of the screen on MD size specifially. Add
-	// some spacing between the content.
+.scroll-scroller
+	// The nav shifts to the right side of the screen on MD size specifially.
+	// Add some spacing between the content below, and allow content to bleed-right.
 	@media $media-md
+		margin-right: -($grid-gutter-width / 2)
 		margin-bottom: $line-height-computed
 
 	@media $media-mobile
-		display: flex
-		overflow-x: scroll
 		margin-bottom: 8px
 
-		.community-channel-card
-			margin-right: 8px
-			width: 200px
+	// We need to target the AppScrollInviewParent child of
+	// AppScrollScroller to make sure things are displaying properly.
+	>>> > div
+		@media $media-lg-up
+			display: flex
+			flex-direction: column
+			align-items: flex-end
+
+		@media $media-mobile
+			display: flex
+
+			.community-channel-card
+				margin-right: 8px
+				width: 200px
 
 .-channels-header
 	margin-top: 10px

--- a/src/app/views/communities/view/overview/_nav/nav.ts
+++ b/src/app/views/communities/view/overview/_nav/nav.ts
@@ -5,6 +5,7 @@ import { COMMUNITY_CHANNEL_PERMISSIONS_ACTION_POSTING } from '../../../../../../
 import { CommunityChannel } from '../../../../../../_common/community/channel/channel.model';
 import { Community } from '../../../../../../_common/community/community.model';
 import { Screen } from '../../../../../../_common/screen/screen-service';
+import AppScrollScroller from '../../../../../../_common/scroll/scroller/scroller.vue';
 import { AppStore } from '../../../../../../_common/store/app-store';
 import AppCommunityChannelCard from '../../../../../components/community/channel/card/card.vue';
 import { AppCommunityPerms } from '../../../../../components/community/perms/perms';
@@ -14,6 +15,7 @@ import { Store } from '../../../../../store/index';
 	components: {
 		AppCommunityPerms,
 		AppCommunityChannelCard,
+		AppScrollScroller,
 	},
 })
 export default class AppCommunitiesViewOverviewNav extends Vue {

--- a/src/app/views/communities/view/overview/_nav/nav.vue
+++ b/src/app/views/communities/view/overview/_nav/nav.vue
@@ -1,40 +1,42 @@
 <template>
 	<nav>
-		<app-community-channel-card
-			:community="community"
-			path="featured"
-			label="Featured"
-			:background-item="community.featured_background"
-			:is-active="activeChannelTitle === 'featured'"
-			:is-unread="isChannelUnread('featured')"
-		/>
-		<app-community-channel-card
-			:community="community"
-			path="all"
-			label="All Posts"
-			:background-item="community.all_background"
-			sort="hot"
-			:is-active="activeChannelTitle === 'all'"
-			:is-unread="isChannelUnread('all')"
-		/>
-
-		<h5 v-if="Screen.isDesktop" class="-channels-header">
-			<translate>Channels</translate>
-		</h5>
-
-		<template v-if="community.channels">
+		<app-scroll-scroller :horizontal="Screen.isMobile" thin>
 			<app-community-channel-card
-				v-for="channel of community.channels"
-				:key="channel.id"
 				:community="community"
-				:path="channel.title"
-				:label="channel.title"
-				:background-item="channel.background"
-				:is-active="activeChannelTitle === channel.title"
-				:is-unread="isChannelUnread(channel.title)"
-				:is-locked="isChannelLocked(channel)"
+				path="featured"
+				label="Featured"
+				:background-item="community.featured_background"
+				:is-active="activeChannelTitle === 'featured'"
+				:is-unread="isChannelUnread('featured')"
 			/>
-		</template>
+			<app-community-channel-card
+				:community="community"
+				path="all"
+				label="All Posts"
+				:background-item="community.all_background"
+				sort="hot"
+				:is-active="activeChannelTitle === 'all'"
+				:is-unread="isChannelUnread('all')"
+			/>
+
+			<h5 v-if="Screen.isDesktop" class="-channels-header">
+				<translate>Channels</translate>
+			</h5>
+
+			<template v-if="community.channels">
+				<app-community-channel-card
+					v-for="channel of community.channels"
+					:key="channel.id"
+					:community="community"
+					:path="channel.title"
+					:label="channel.title"
+					:background-item="channel.background"
+					:is-active="activeChannelTitle === channel.title"
+					:is-unread="isChannelUnread(channel.title)"
+					:is-locked="isChannelLocked(channel)"
+				/>
+			</template>
+		</app-scroll-scroller>
 	</nav>
 </template>
 

--- a/src/app/views/communities/view/overview/_nav/nav.vue
+++ b/src/app/views/communities/view/overview/_nav/nav.vue
@@ -1,41 +1,43 @@
 <template>
 	<nav>
 		<app-scroll-scroller :horizontal="Screen.isMobile" thin>
-			<app-community-channel-card
-				:community="community"
-				path="featured"
-				label="Featured"
-				:background-item="community.featured_background"
-				:is-active="activeChannelTitle === 'featured'"
-				:is-unread="isChannelUnread('featured')"
-			/>
-			<app-community-channel-card
-				:community="community"
-				path="all"
-				label="All Posts"
-				:background-item="community.all_background"
-				sort="hot"
-				:is-active="activeChannelTitle === 'all'"
-				:is-unread="isChannelUnread('all')"
-			/>
-
-			<h5 v-if="Screen.isDesktop" class="-channels-header">
-				<translate>Channels</translate>
-			</h5>
-
-			<template v-if="community.channels">
+			<div>
 				<app-community-channel-card
-					v-for="channel of community.channels"
-					:key="channel.id"
 					:community="community"
-					:path="channel.title"
-					:label="channel.title"
-					:background-item="channel.background"
-					:is-active="activeChannelTitle === channel.title"
-					:is-unread="isChannelUnread(channel.title)"
-					:is-locked="isChannelLocked(channel)"
+					path="featured"
+					label="Featured"
+					:background-item="community.featured_background"
+					:is-active="activeChannelTitle === 'featured'"
+					:is-unread="isChannelUnread('featured')"
 				/>
-			</template>
+				<app-community-channel-card
+					:community="community"
+					path="all"
+					label="All Posts"
+					:background-item="community.all_background"
+					sort="hot"
+					:is-active="activeChannelTitle === 'all'"
+					:is-unread="isChannelUnread('all')"
+				/>
+
+				<h5 v-if="Screen.isDesktop" class="-channels-header">
+					<translate>Channels</translate>
+				</h5>
+
+				<template v-if="community.channels">
+					<app-community-channel-card
+						v-for="channel of community.channels"
+						:key="channel.id"
+						:community="community"
+						:path="channel.title"
+						:label="channel.title"
+						:background-item="channel.background"
+						:is-active="activeChannelTitle === channel.title"
+						:is-unread="isChannelUnread(channel.title)"
+						:is-locked="isChannelLocked(channel)"
+					/>
+				</template>
+			</div>
 		</app-scroll-scroller>
 	</nav>
 </template>

--- a/src/app/views/communities/view/overview/_nav/nav.vue
+++ b/src/app/views/communities/view/overview/_nav/nav.vue
@@ -1,7 +1,7 @@
 <template>
 	<nav>
 		<app-scroll-scroller :horizontal="Screen.isMobile" thin>
-			<div>
+			<div class="-inner">
 				<app-community-channel-card
 					:community="community"
 					path="featured"


### PR DESCRIPTION
- Added `width: 10px` as a webkit default for `AppScrollScroller`, and rounded corners for the default bar.
- Added `AppScrollScroller` to `AppCommunitiesViewOverviewNav` for when we use a scrollbar on community cards with mobile screens.