### PR TITLE
Pass a better property to ScrollInviewParent

### DIFF
--- a/src/_common/scroll/scroller/scroller.ts
+++ b/src/_common/scroll/scroller/scroller.ts
@@ -19,8 +19,10 @@ export default class AppScrollScroller extends Vue {
 	hideScrollbar!: boolean;
 
 	isMounted = GJ_IS_SSR;
+	scrollElement: HTMLElement | null = null;
 
 	mounted() {
+		this.scrollElement = this.$el as HTMLElement;
 		this.isMounted = true;
 	}
 

--- a/src/_common/scroll/scroller/scroller.vue
+++ b/src/_common/scroll/scroller/scroller.vue
@@ -7,7 +7,7 @@
 			'-hide-scrollbar': hideScrollbar,
 		}"
 	>
-		<app-scroll-inview-parent v-if="isMounted" :scroller="$el">
+		<app-scroll-inview-parent v-if="isMounted" :scroller="scrollElement">
 			<slot />
 		</app-scroll-inview-parent>
 	</div>


### PR DESCRIPTION
Assign `this.$el as HTMLElement` to `scrollElement` and pass that to `AppScrollInviewParent`, instead of just passing `$el` in the template. 