### PR TITLE
Fix occasional 1px bottom backdrop bleed in MediaItemPost

### DIFF
--- a/src/_common/media-item/backdrop/backdrop.vue
+++ b/src/_common/media-item/backdrop/backdrop.vue
@@ -11,17 +11,16 @@
 
 
 .media-item-backdrop
+	position: relative
+	z-index: 0
 	display: flex
 	overflow: hidden
 	width: 100%
 	height: 100%
-	position: relative
-
-	> *
-		position: relative
 
 	.-color
 		position: absolute
+		z-index: -1
 		top: 1px
 		right: 1px
 		bottom: 1px

--- a/src/_common/media-item/backdrop/backdrop.vue
+++ b/src/_common/media-item/backdrop/backdrop.vue
@@ -11,16 +11,17 @@
 
 
 .media-item-backdrop
-	position: relative
-	z-index: 0
 	display: flex
 	overflow: hidden
 	width: 100%
 	height: 100%
+	position: relative
+
+	> *
+		position: relative
 
 	.-color
 		position: absolute
-		z-index: -1
 		top: 1px
 		right: 1px
 		bottom: 1px

--- a/src/_common/media-item/post/post.vue
+++ b/src/_common/media-item/post/post.vue
@@ -3,6 +3,7 @@
 		<app-responsive-dimensions
 			class="-item-media"
 			:class="{
+				'-ssr': GJ_IS_SSR,
 				'-filled': isFilled,
 			}"
 			:ratio="mediaItem.width / mediaItem.height"
@@ -58,8 +59,23 @@
 // The "item" gets the correct dimensions applied, so we want to stretch
 // out any image or video in the item to be full width/height.
 .-img, .-video
-	width: 100%
+	display: block
+	width: inherit
+	margin-left: auto
+	margin-right: auto
+	position: absolute
+	top: 0
+	right: 0
+	bottom: 0
+	left: 0
+	overflow: hidden
 
+	// For SSR responsive-dimensions component doesn't work, so we want
+	// to instead just try showing the media however the browser would
+	// show it.
+	.-ssr &
+		position: static
+		width: 100%
 </style>
 
 <script lang="ts" src="./post"></script>

--- a/src/_common/media-item/post/post.vue
+++ b/src/_common/media-item/post/post.vue
@@ -3,7 +3,6 @@
 		<app-responsive-dimensions
 			class="-item-media"
 			:class="{
-				'-ssr': GJ_IS_SSR,
 				'-filled': isFilled,
 			}"
 			:ratio="mediaItem.width / mediaItem.height"
@@ -59,23 +58,8 @@
 // The "item" gets the correct dimensions applied, so we want to stretch
 // out any image or video in the item to be full width/height.
 .-img, .-video
-	display: block
-	width: inherit
-	margin-left: auto
-	margin-right: auto
-	position: absolute
-	top: 0
-	right: 0
-	bottom: 0
-	left: 0
-	overflow: hidden
+	width: 100%
 
-	// For SSR responsive-dimensions component doesn't work, so we want
-	// to instead just try showing the media however the browser would
-	// show it.
-	.-ssr &
-		position: static
-		width: 100%
 </style>
 
 <script lang="ts" src="./post"></script>

--- a/src/_common/media-item/post/post.vue
+++ b/src/_common/media-item/post/post.vue
@@ -55,11 +55,10 @@
 .-backdrop
 	change-bg('bg-offset')
 
-// The "item" gets the correct dimensions applied, so we want to stretch
-// out any image or video in the item to be full width/height.
+// Set the width to be what AppResponsiveDimensions gives us,
+// so we don't overflow past what it sets.
 .-img, .-video
 	width: 100%
-
 </style>
 
 <script lang="ts" src="./post"></script>


### PR DESCRIPTION
`AppMediaItemBackdrop` would sometimes bleed through 1px on the bottom of `AppMediaItemPost` items.
This PR simplifies the styling to get post items to match the dimensions of `AppResponsiveDimensions`