### PR TITLE
Fix backdrop z-index issues when SSR

### DIFF
--- a/src/_common/media-item/backdrop/backdrop.vue
+++ b/src/_common/media-item/backdrop/backdrop.vue
@@ -11,17 +11,16 @@
 
 
 .media-item-backdrop
+	position: relative
+	z-index: 0
 	display: flex
 	overflow: hidden
 	width: 100%
 	height: 100%
-	position: relative
-
-	> *
-		position: relative
 
 	.-color
 		position: absolute
+		z-index: -1
 		top: 1px
 		right: 1px
 		bottom: 1px


### PR DESCRIPTION
Use better z-indexing on `AppMediaItemBackdrop` - fixes z-index issues when using SSR.

![image](https://user-images.githubusercontent.com/2914500/81597023-044f4180-9393-11ea-9796-5ccea803ed0a.png)
