### PR TITLE
Fix paypal payment form

### DIFF
--- a/src/_common/game/package/payment-form/payment-form.ts
+++ b/src/_common/game/package/payment-form/payment-form.ts
@@ -227,6 +227,7 @@ export default class FormGamePackagePayment extends BaseForm<any>
 		if (this.addresses.length) {
 			if (checkoutType === 'paypal') {
 				this.checkoutPaypal();
+				this.$refs.form.submit();
 				return;
 			} else if (checkoutType === 'wallet') {
 				this.checkoutWallet();


### PR DESCRIPTION
When the user already had a saved address, clicking the paypal button in the payment form didn't actually submit the form.