### PR TITLE
Add tooltip touch support through 'touchable' modifier

### DIFF
--- a/src/_common/game/package/payment-form/payment-form.vue
+++ b/src/_common/game/package/payment-form/payment-form.vue
@@ -353,13 +353,13 @@
 							<p v-if="calculatedAddressTax && addressTaxAmount > 0" class="anim-fade-in small">
 								+{{ addressTaxAmount | currency }}
 								<translate>tax</translate>
-								<span
-									v-app-tooltip="
+								<app-jolticon
+									class="text-muted"
+									icon="help-circle"
+									v-app-tooltip.touchable="
 										$gettext(`We are required to collect taxes on orders for certain regions.`)
 									"
-								>
-									<app-jolticon class="text-muted" icon="help-circle" />
-								</span>
+								/>
 							</p>
 
 							<div v-if="!hasSufficientWalletFunds" class="alert">

--- a/src/_common/popper/popper.styl
+++ b/src/_common/popper/popper.styl
@@ -14,6 +14,8 @@ $-transition-time = 200ms
 	display: block !important
 
 .popper-wrapper
+	position: absolute
+	top: 0
 	z-index: $zindex-popover
 	outline: 0
 	transition: opacity $-transition-time, visibility $-transition-time

--- a/src/_common/popper/popper.ts
+++ b/src/_common/popper/popper.ts
@@ -183,6 +183,13 @@ export default class AppPopper extends Vue {
 		Popper.registerPopper(this.$router, this);
 	}
 
+	beforeDestroy() {
+		// We have to remove open poppers if their reference gets destroyed.
+		if (this.isVisible) {
+			document.body.removeChild(this.$refs.popper);
+		}
+	}
+
 	destroyed() {
 		Popper.deregisterPopper(this);
 		this.clearHideTimeout();
@@ -326,7 +333,7 @@ export default class AppPopper extends Vue {
 		this.addBackdrop();
 	}
 
-	private hide() {
+	hide() {
 		// In case a popper was hidden from something other than a click,
 		// like right-clicking a cbar item or Popover.hideAll() being triggered.
 		document.removeEventListener('click', this.onClickAway, true);

--- a/src/_common/popper/popper.ts
+++ b/src/_common/popper/popper.ts
@@ -302,8 +302,8 @@ export default class AppPopper extends Vue {
 		this.clearHideTimeout();
 
 		// Clean up any remaining popper elements and instances
-		if (document.body.contains(this.$refs.popper)) {
-			document.body.removeChild(this.$refs.popper);
+		if (this.$refs.popper) {
+			this.$refs.popper.remove();
 		}
 
 		if (this.popperInstance) {

--- a/src/_common/tooltip/tooltip-directive.ts
+++ b/src/_common/tooltip/tooltip-directive.ts
@@ -1,21 +1,13 @@
 import { DirectiveOptions } from 'vue';
 import { TooltipModel } from './tooltip-model';
 
-/**
- * If using 'touchable' modifier on 'AppJolticon', you much attach
- * the following to 'AppJolticon' itself - not an element wrapping it:
- *
- * @touchend.native.prevent		// if there is a router-link or <a> parent to stop the route change
- * v-app-tooltip.touchable=""	// allow touch events to trigger tooltips
- *
- * If we put these on a wrapping element instead of AppJolticon itself,
- * the 'focus' and 'pointerup' events won't properly trigger and we
- * can end up clicking the link behind the jolticon.
- */
-
 let state = new WeakMap<HTMLElement, TooltipModel>();
 
 const TooltipDirective: DirectiveOptions = {
+	/**
+	 * Never attach a 'touchable' modifier to a link.
+	 * It will stop the link from working.
+	 */
 	bind(el, binding) {
 		let tooltip = new TooltipModel(el, binding);
 		state.set(el, tooltip);

--- a/src/_common/tooltip/tooltip-directive.ts
+++ b/src/_common/tooltip/tooltip-directive.ts
@@ -1,6 +1,18 @@
 import { DirectiveOptions } from 'vue';
 import { TooltipModel } from './tooltip-model';
 
+/**
+ * If using 'touchable' modifier on 'AppJolticon', you much attach
+ * the following to 'AppJolticon' itself - not an element wrapping it:
+ *
+ * @touchend.native.prevent		// if there is a router-link or <a> parent to stop the route change
+ * v-app-tooltip.touchable=""	// allow touch events to trigger tooltips
+ *
+ * If we put these on a wrapping element instead of AppJolticon itself,
+ * the 'focus' and 'pointerup' events won't properly trigger and we
+ * can end up clicking the link behind the jolticon.
+ */
+
 let state = new WeakMap<HTMLElement, TooltipModel>();
 
 const TooltipDirective: DirectiveOptions = {

--- a/src/_common/tooltip/tooltip-model.ts
+++ b/src/_common/tooltip/tooltip-model.ts
@@ -58,10 +58,9 @@ export class TooltipModel {
 
 		el.addEventListener('pointerup', this.onPointerUp);
 		el.addEventListener('pointerenter', this.onPointerEnter);
-		el.addEventListener('pointerleave', this.onLeaveTrigger);
-		el.addEventListener('focusout', this.onLeaveTrigger);
-		// TODO: Add some kind of clickAway listener/handler
-		// to hide tooltip on mobile scroll.
+		el.addEventListener('pointerleave', this.onPointerLeave);
+		el.addEventListener('focusout', this.onFocusOut);
+		// TODO: Add some kind of clickAway listener/handler to hide tooltip on mobile scroll.
 		this.update(binding);
 	}
 
@@ -85,7 +84,7 @@ export class TooltipModel {
 	}
 
 	private onPointerUp = (event: PointerEvent) => {
-		// Mobile should use tooltip triggers as toggles,
+		// Touch should use tooltip triggers as toggles,
 		// but mouse events should only hide tooltips.
 		if (event.pointerType === 'touch' && this.touchable) {
 			this.isActive = !this.isActive;
@@ -97,7 +96,7 @@ export class TooltipModel {
 	};
 
 	private onPointerEnter = (event: PointerEvent) => {
-		// We don't need this for touch
+		// We don't want to check for mouseenter on touch.
 		if (event.pointerType === 'touch') {
 			return;
 		}
@@ -106,9 +105,9 @@ export class TooltipModel {
 		assignActiveTooltip(this);
 	};
 
-	private onLeaveTrigger = (event: PointerEvent) => {
-		// This stops the event in 'pointerleave' on mobile,
-		// but will still work during 'focusout'.
+	private onPointerLeave = (event: PointerEvent) => {
+		// This stops the event from 'pointerleave'
+		// triggering on tap for touch.
 		if (event.pointerType === 'touch') {
 			return;
 		}
@@ -117,11 +116,15 @@ export class TooltipModel {
 		assignActiveTooltip(this);
 	};
 
+	private onFocusOut = () => {
+		this.isActive = false;
+	};
+
 	destroy() {
 		this.el.removeEventListener('pointerup', this.onPointerUp);
 		this.el.removeEventListener('pointerenter', this.onPointerEnter);
-		this.el.removeEventListener('pointerleave', this.onLeaveTrigger);
-		this.el.removeEventListener('focusout', this.onLeaveTrigger);
+		this.el.removeEventListener('pointerleave', this.onPointerLeave);
+		this.el.removeEventListener('focusout', this.onFocusOut);
 	}
 }
 

--- a/src/_common/tooltip/tooltip-model.ts
+++ b/src/_common/tooltip/tooltip-model.ts
@@ -69,6 +69,7 @@ export class TooltipModel {
 			el.style.outline = 'none';
 		}
 
+		el.addEventListener('touchend', this.onTouchEnd);
 		el.addEventListener('pointerup', this.onPointerUp);
 		el.addEventListener('pointerenter', this.onPointerEnter);
 		el.addEventListener('pointerleave', this.onPointerLeave);
@@ -95,19 +96,25 @@ export class TooltipModel {
 		this.text = binding.value?.content || binding.value;
 	}
 
-	private onPointerUp = (event: PointerEvent) => {
-		// Touch uses tooltip triggers as toggles,
-		// but mouse events should only hide tooltips.
-		if (event.pointerType === 'touch' && this.touchable) {
+	private onTouchEnd = () => {
+		if (this.touchable) {
 			this.isActive = !this.isActive;
 
 			// If the direct parent of the directive is a router-link or <a>,
 			// we need to manually set the focus for 'focusout' to work properly.
-			this.el.focus();
-		} else {
-			this.isActive = false;
+			// this.el.focus();
+			assignActiveTooltip(this);
+		}
+	};
+
+	private onPointerUp = (event: PointerEvent) => {
+		// Touch uses tooltip triggers as toggles,
+		// but mouse events should only hide tooltips.
+		if (event.pointerType === 'touch') {
+			return;
 		}
 
+		this.isActive = false;
 		assignActiveTooltip(this);
 	};
 
@@ -137,6 +144,7 @@ export class TooltipModel {
 	};
 
 	destroy() {
+		this.el.removeEventListener('touchend', this.onTouchEnd);
 		this.el.removeEventListener('pointerup', this.onPointerUp);
 		this.el.removeEventListener('pointerenter', this.onPointerEnter);
 		this.el.removeEventListener('pointerleave', this.onPointerLeave);

--- a/src/_common/tooltip/tooltip-model.ts
+++ b/src/_common/tooltip/tooltip-model.ts
@@ -102,7 +102,7 @@ export class TooltipModel {
 
 			// If the direct parent of the directive is a router-link or <a>,
 			// we need to manually set the focus for 'focusout' to work properly.
-			// this.el.focus();
+			this.el.focus();
 			assignActiveTooltip(this);
 		}
 	};

--- a/src/_common/tooltip/tooltip.ts
+++ b/src/_common/tooltip/tooltip.ts
@@ -1,4 +1,5 @@
 import flip from '@popperjs/core/lib/modifiers/flip';
+import hide from '@popperjs/core/lib/modifiers/hide';
 import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow';
 import { createPopper, Instance, Options } from '@popperjs/core/lib/popper-lite';
 import Vue from 'vue';
@@ -42,7 +43,7 @@ export default class AppTooltip extends Vue {
 
 		const options: Options = {
 			placement: this.tooltip.placement,
-			modifiers: [flip, preventOverflow],
+			modifiers: [flip, preventOverflow, hide],
 			strategy: 'absolute',
 		};
 

--- a/src/_common/tooltip/tooltip.vue
+++ b/src/_common/tooltip/tooltip.vue
@@ -21,6 +21,7 @@
 	line-height: 1.4
 	z-index: $zindex-tooltip
 	pointer-events: none
+	transition: opacity 200ms, visibility 200ms
 
 	&-inner
 		rounded-corners()
@@ -30,8 +31,7 @@
 		color: $tooltip-color
 		background-color: $tooltip-bg
 
-	&.-hide
+	&.-hide, &[data-popper-reference-hidden]
 		opacity: 0
 		visibility: hidden
-		transition: opacity 200ms, visibility 200ms
 </style>

--- a/src/app/components/event-item/controls/fireside-post/stats/stats.vue
+++ b/src/app/components/event-item/controls/fireside-post/stats/stats.vue
@@ -21,7 +21,6 @@
 		<app-jolticon
 			class="hidden-xs"
 			icon="help-circle"
-			@touchend.native.prevent
 			v-app-tooltip.touchable="
 				$gettext(
 					'An expand is some sort of interaction with your post. For example, playing a video post, or clicking into your post.'

--- a/src/app/components/event-item/controls/fireside-post/stats/stats.vue
+++ b/src/app/components/event-item/controls/fireside-post/stats/stats.vue
@@ -18,16 +18,16 @@
 			%{ count } expand
 		</translate>
 
-		<span
+		<app-jolticon
 			class="hidden-xs"
-			v-app-tooltip="
+			icon="help-circle"
+			@touchend.native.prevent
+			v-app-tooltip.touchable="
 				$gettext(
 					'An expand is some sort of interaction with your post. For example, playing a video post, or clicking into your post.'
 				)
 			"
-		>
-			<app-jolticon icon="help-circle" />
-		</span>
+		/>
 	</div>
 </template>
 

--- a/src/app/components/shell/account-popover/account-popover.vue
+++ b/src/app/components/shell/account-popover/account-popover.vue
@@ -116,7 +116,8 @@
 							<app-jolticon
 								class="pull-right"
 								icon="help-circle"
-								v-app-tooltip="
+								@touchend.native.prevent
+								v-app-tooltip.touchable="
 									$gettext(`These are your available funds to either buy games with or withdraw.`)
 								"
 							/>

--- a/src/app/components/shell/account-popover/account-popover.vue
+++ b/src/app/components/shell/account-popover/account-popover.vue
@@ -116,7 +116,6 @@
 							<app-jolticon
 								class="pull-right"
 								icon="help-circle"
-								@touchend.native.prevent
 								v-app-tooltip.touchable="
 									$gettext(`These are your available funds to either buy games with or withdraw.`)
 								"

--- a/src/app/views/dashboard/account/withdraw-funds/withdraw-funds.vue
+++ b/src/app/views/dashboard/account/withdraw-funds/withdraw-funds.vue
@@ -24,7 +24,7 @@
 							<app-jolticon
 								class="text-muted"
 								icon="help-circle"
-								v-app-tooltip="
+								v-app-tooltip.touchable="
 									$gettext(
 										`To account for refunds, chargebacks, and fraud, we hold on to sales revenue for 7 days.`
 									)

--- a/src/app/views/dashboard/games/manage/api/overview/overview.vue
+++ b/src/app/views/dashboard/games/manage/api/overview/overview.vue
@@ -112,7 +112,7 @@
 							<translate>dash.games.api.overview.trophies_exp_label</translate>
 							<app-jolticon
 								icon="help-circle"
-								v-app-tooltip="$gettext(`dash.games.api.overview.trophies_exp_tooltip`)"
+								v-app-tooltip.touchable="$gettext(`dash.games.api.overview.trophies_exp_tooltip`)"
 							/>
 						</div>
 						<div class="stat-big-digit">
@@ -163,7 +163,7 @@
 							<translate>dash.games.api.overview.scores_label</translate>
 							<app-jolticon
 								icon="help-circle"
-								v-app-tooltip="$gettext(`dash.games.api.overview.scores_tooltip`)"
+								v-app-tooltip.touchable="$gettext(`dash.games.api.overview.scores_tooltip`)"
 							/>
 						</div>
 						<div class="stat-big-digit">
@@ -177,7 +177,7 @@
 							<translate>dash.games.api.overview.scores_users_label</translate>
 							<app-jolticon
 								icon="help-circle"
-								v-app-tooltip="$gettext(`dash.games.api.overview.scores_users_tooltip`)"
+								v-app-tooltip.touchable="$gettext(`dash.games.api.overview.scores_users_tooltip`)"
 							/>
 						</div>
 						<div class="stat-big-digit">
@@ -205,7 +205,7 @@
 							<translate>dash.games.api.overview.data_items_label</translate>
 							<app-jolticon
 								icon="help-circle"
-								v-app-tooltip="$gettext(`dash.games.api.overview.data_items_tooltip`)"
+								v-app-tooltip.touchable="$gettext(`dash.games.api.overview.data_items_tooltip`)"
 							/>
 						</div>
 						<div class="stat-big-digit">

--- a/src/app/views/discover/games/view/overview/_supporters/supporters.vue
+++ b/src/app/views/discover/games/view/overview/_supporters/supporters.vue
@@ -5,7 +5,7 @@
 			<app-jolticon
 				class="text-muted"
 				icon="help-circle"
-				v-app-tooltip="
+				v-app-tooltip.touchable="
 					$gettext(
 						`The kind people that supported by paying more than the minimum. Sorted by amount contributed.`
 					)

--- a/typings/tooltip.d.ts
+++ b/typings/tooltip.d.ts
@@ -1,3 +1,0 @@
-declare module 'v-tooltip' {
-	export const VTooltip: any;
-}


### PR DESCRIPTION
Add a `touchable` modifier to the AppTooltip directive to allow tooltips to display on touch events. Then we can allow tooltips on mobile for our `?` icons.