### PR TITLE
Fix user header menu wrapping and breaking content

### DIFF
--- a/src/app/components/page-header/page-header.styl
+++ b/src/app/components/page-header/page-header.styl
@@ -3,6 +3,24 @@
 
 $-cover-buttons-height = $button-md-line-height + 20px
 
+.-index
+	.-controls, .-nav
+		padding: 0 20px
+
+	@media $media-xs
+		.-controls, .-nav
+			padding: 0 15px
+
+	@media $media-lg-up
+		display: flex
+		flex-direction: row-reverse
+		justify-content: flex-end
+
+		.-controls
+			max-width: 33.333333%
+			flex: auto
+			margin-left: auto
+
 .page-header
 	// Bootstrap has styling on .page-header.
 	// Gotta override.

--- a/src/app/components/page-header/page-header.styl
+++ b/src/app/components/page-header/page-header.styl
@@ -5,11 +5,11 @@ $-cover-buttons-height = $button-md-line-height + 20px
 
 .-index
 	.-controls, .-nav
-		padding: 0 20px
+		padding: 0 ($grid-gutter-width / 2)
 
 	@media $media-xs
 		.-controls, .-nav
-			padding: 0 15px
+			padding: 0 ($grid-gutter-width-xs / 2)
 
 	@media $media-lg-up
 		display: flex

--- a/src/app/components/page-header/page-header.vue
+++ b/src/app/components/page-header/page-header.vue
@@ -105,15 +105,15 @@
 					<div class="container">
 						<div class="row">
 							<div :class="colClasses">
-								<div class="row">
-									<div v-if="hasControls" class="col-lg-4 col-lg-push-8">
+								<div class="-index row">
+									<div v-if="hasControls" class="-controls">
 										<div class="page-header-controls">
 											<slot name="controls" />
 										</div>
 									</div>
 									<div
+										class="-nav"
 										:class="{
-											'col-lg-8 col-lg-pull-4': hasControls,
 											'col-xs-12': !hasControls,
 										}"
 									>


### PR DESCRIPTION
Change from using `col-lg-X` styling to using flex so we can shrink the controls if needed.

This will fix the content breaking on profiles that wrap the nav when there is too much information.
To do this it means that the control button(s), like 'Follow' or 'Edit', must shrink to make space if needed until they reach a breakpoint that puts them on a different line (< 1200px).

1200px wide with high counts for the nav buttons
![image](https://user-images.githubusercontent.com/2914500/83336296-3d871d00-a280-11ea-807a-3b37ccbfa573.png)

