### PR TITLE
Fix ScrollInview component to always trigger.

### DIFF
--- a/src/_common/scroll/inview/container.ts
+++ b/src/_common/scroll/inview/container.ts
@@ -48,9 +48,14 @@ export class ScrollInviewContainer {
 					? entry.intersectionRatio === 1
 					: entry.isIntersecting;
 
-			if (isInView !== item.inView) {
-				this.queueChange(() => (item.inView = isInView));
-			}
+			this.queueChange(() => {
+				item.inView = isInView;
+				if (isInView) {
+					item.emitInView();
+				} else {
+					item.emitOutView();
+				}
+			});
 		}
 	};
 

--- a/src/_common/scroll/inview/inview.ts
+++ b/src/_common/scroll/inview/inview.ts
@@ -1,5 +1,5 @@
 import Vue, { CreateElement } from 'vue';
-import { Component, Emit, Prop, Watch } from 'vue-property-decorator';
+import { Component, Emit, Prop } from 'vue-property-decorator';
 import { findRequiredVueParent } from '../../../utils/vue';
 import { AppScrollInviewParent } from './parent';
 
@@ -33,7 +33,7 @@ export class AppScrollInview extends Vue {
 
 	// This will get set by AppScrollInviewContainer as this element goes into
 	// and out of view.
-	inView = false;
+	inView: null | boolean = null;
 
 	// This is the initial value of the margin prop.
 	// The margin prop cannot be reactive because we can't easily
@@ -48,17 +48,9 @@ export class AppScrollInview extends Vue {
 		return this.parent.getContainer(this.initMargin);
 	}
 
+	// These will get called by ScrollInviewContainer.
 	@Emit('inview') emitInView() {}
 	@Emit('outview') emitOutView() {}
-
-	@Watch('inView')
-	inViewChanged() {
-		if (this.inView) {
-			this.emitInView();
-		} else {
-			this.emitOutView();
-		}
-	}
 
 	mounted() {
 		this.initMargin = this.margin;


### PR DESCRIPTION
Since it collects the changes to apply, and then applies in bulk during an RAF callback, it was triggering a race condition.

We were only triggering the inview change to happen if the new value is different than the current. However, since we queue up the changes, it wasn't triggering the boolean flip to happen in cases where it flips back and forth really fast.

For example, if you go from false to true and then true to false before the RAF callback happened, the second change wouldn't queue since it is still false at the time the second change tries to happen.

I also tried keeping it as fast as possible by removing a watch that was set on the inview vue components.