### PR TITLE
Fetch and pass chat token instead of frontend

### DIFF
--- a/src/_common/environment/environment.service.ts
+++ b/src/_common/environment/environment.service.ts
@@ -41,6 +41,7 @@ export class Environment {
 	static gameserverApiHost = 'https://gamejolt.net';
 	static activityStreamHost = 'https://activity.gamejolt.com';
 	static chatHost = 'https://chatex.gamejolt.com/chatex/host';
+	static chatToken = 'https://chatex.gamejolt.com/chatex/token';
 	static widgetHost = 'https://widgets.gamejolt.com';
 	static gridHost = 'https://grid.gamejolt.com/grid/host';
 	static recaptchaSiteKey = '6Led_UAUAAAAAB_ptIOOlAF5DFK9YM7Qi_7z8iKk';
@@ -65,6 +66,7 @@ if (GJ_ENVIRONMENT === 'development') {
 	Environment.gameserverApiHost = 'http://development.gamejolt.com';
 	Environment.activityStreamHost = 'http://activity.development.gamejolt.com';
 	Environment.chatHost = 'http://chat.development.gamejolt.com/chatex/host';
+	Environment.chatToken = 'http://chat.development.gamejolt.com/chatex/token';
 	Environment.widgetHost = 'http://localhost:8086';
 	Environment.gridHost = 'http://grid.development.gamejolt.com/grid/host';
 	Environment.recaptchaSiteKey = '6LcwTkEUAAAAAHTT67TB8gkM0ft5hUzz_r_tFFaT';

--- a/src/_common/environment/environment.service.ts
+++ b/src/_common/environment/environment.service.ts
@@ -40,8 +40,7 @@ export class Environment {
 	static apiHost = 'https://gamejolt.com';
 	static gameserverApiHost = 'https://gamejolt.net';
 	static activityStreamHost = 'https://activity.gamejolt.com';
-	static chatHost = 'https://chatex.gamejolt.com/chatex/host';
-	static chatToken = 'https://chatex.gamejolt.com/chatex/token';
+	static chat = 'https://chatex.gamejolt.com/chatex';
 	static widgetHost = 'https://widgets.gamejolt.com';
 	static gridHost = 'https://grid.gamejolt.com/grid/host';
 	static recaptchaSiteKey = '6Led_UAUAAAAAB_ptIOOlAF5DFK9YM7Qi_7z8iKk';
@@ -65,8 +64,7 @@ if (GJ_ENVIRONMENT === 'development') {
 	Environment.apiHost = GJ_TUNNELS.backend || 'http://development.gamejolt.com';
 	Environment.gameserverApiHost = 'http://development.gamejolt.com';
 	Environment.activityStreamHost = 'http://activity.development.gamejolt.com';
-	Environment.chatHost = 'http://chat.development.gamejolt.com/chatex/host';
-	Environment.chatToken = 'http://chat.development.gamejolt.com/chatex/token';
+	Environment.chat = 'http://chat.development.gamejolt.com/chatex';
 	Environment.widgetHost = 'http://localhost:8086';
 	Environment.gridHost = 'http://grid.development.gamejolt.com/grid/host';
 	Environment.recaptchaSiteKey = '6LcwTkEUAAAAAHTT67TB8gkM0ft5hUzz_r_tFFaT';

--- a/src/app/components/chat/client.ts
+++ b/src/app/components/chat/client.ts
@@ -170,12 +170,16 @@ async function connect(chat: ChatClient) {
 
 	// get hostname from loadbalancer first
 	const hostResult = await pollRequest(chat, 'Select server', () =>
-		Axios.get(Environment.chatHost, { ignoreLoadingBar: true, timeout: 3000 })
+		Axios.get(`${Environment.chat}/host`, { ignoreLoadingBar: true, timeout: 3000 })
 	);
 
 	// Fetch auth token for chat.
 	const tokenResult = await pollRequest(chat, 'Fetch auth token', () =>
-		Axios.post(Environment.chatToken, { frontend }, { ignoreLoadingBar: true, timeout: 3000 })
+		Axios.post(
+			`${Environment.chat}/token`,
+			{ frontend },
+			{ ignoreLoadingBar: true, timeout: 3000 }
+		)
 	);
 
 	if (chatId !== chat.id) {

--- a/src/app/components/chat/client.ts
+++ b/src/app/components/chat/client.ts
@@ -173,18 +173,24 @@ async function connect(chat: ChatClient) {
 		Axios.get(Environment.chatHost, { ignoreLoadingBar: true, timeout: 3000 })
 	);
 
+	// Fetch auth token for chat.
+	const tokenResult = await pollRequest(chat, 'Fetch auth token', () =>
+		Axios.post(Environment.chatToken, { frontend }, { ignoreLoadingBar: true, timeout: 3000 })
+	);
+
 	if (chatId !== chat.id) {
 		return;
 	}
 
 	const host = `${hostResult.data}`;
+	const token = tokenResult.data.token;
 
 	console.log('[Chat] Server selected:', host);
 
 	// heartbeat is 30 seconds, backend disconnects after 40 seconds
 	chat.socket = new Socket(host, {
 		heartbeatIntervalMs: 30000,
-		params: { frontend },
+		params: { token },
 	});
 
 	// HACK


### PR DESCRIPTION
Now using the `chatex/token` to generate a token. This token gets passed to the socket connection instead of the frontend cookie.