### PR TITLE
Get rid of channel card unread blip pulse animation.

### DIFF
--- a/src/app/components/community/channel/card/card.styl
+++ b/src/app/components/community/channel/card/card.styl
@@ -96,16 +96,3 @@
 			border: 2px solid var(--theme-bg-offset)
 			border-radius: 50%
 			filter: drop-shadow(0 0 7px var(--theme-notice))
-			animation-name: unread
-			animation-duration: 2s
-			animation-iteration-count: infinite
-
-@keyframes unread
-	0%
-		filter: drop-shadow(0 0 1px var(--theme-notice))
-
-	50%
-		filter: drop-shadow(0 0 7px var(--theme-notice))
-
-	100%
-		filter: drop-shadow(0 0 1px var(--theme-notice))


### PR DESCRIPTION
It was spiking CPU for browsers that don't do hardware composing or something.