### PR TITLE
Fix lightbox swipes breaking with iframes

### DIFF
--- a/src/_common/lightbox/lightbox.styl
+++ b/src/_common/lightbox/lightbox.styl
@@ -9,8 +9,9 @@ $-controls-padding = 10px
 	.dragging &
 		cursor: grabbing
 
-		// iframe elements don't allow events to bubble back to the root document, so we need to
-		// prevent all pointer events while dragging to keep our cursor context in the root document.
+		// iframe elements don't allow events to bubble back to the root document, so we need
+		// to prevent all pointer events while dragging to keep our cursor context in the root
+		// document - otherwise youtube and other iframe embeds will break the dragging.
 		>>> iframe
 			pointer-events: none
 

--- a/src/_common/lightbox/lightbox.styl
+++ b/src/_common/lightbox/lightbox.styl
@@ -9,6 +9,8 @@ $-controls-padding = 10px
 	.dragging &
 		cursor: grabbing
 
+		// iframe elements don't allow events to bubble back to the root document, so we need to
+		// prevent all pointer events while dragging to keep our cursor context in the root document.
 		>>> iframe
 			pointer-events: none
 

--- a/src/_common/lightbox/lightbox.styl
+++ b/src/_common/lightbox/lightbox.styl
@@ -6,8 +6,11 @@ $-button-size = 90px
 $-controls-padding = 10px
 
 .media-bar-lightbox
-	&.dragging
+	.dragging &
 		cursor: grabbing
+
+		>>> iframe
+			pointer-events: none
 
 .-inner
 	display: flex

--- a/src/_common/lightbox/lightbox.vue
+++ b/src/_common/lightbox/lightbox.vue
@@ -5,7 +5,7 @@
 			@panstart="panStart"
 			@panmove="pan"
 			@panend="panEnd"
-			:pan-options="{ direction: 'horizontal' }"
+			:pan-options="{ threshold: 0 }"
 		>
 			<app-shortkey shortkey="arrowleft" @press="goPrev" />
 			<app-shortkey shortkey="arrowright" @press="goNext" />


### PR DESCRIPTION
This PR allows lightbox dragging to be triggered on all directions, with no threshold so it adds the `dragging` class immediately.

This sets `pointer-events: none` on iframes in lightbox when the `dragging` class exists, fixing the `panend` event not triggering because the iframe can't bubble events back to our root document.