### PR TITLE
Add ThemeSvg testing to the styleguide

### DIFF
--- a/src/_common/theme/svg/svg-styleguide.ts
+++ b/src/_common/theme/svg/svg-styleguide.ts
@@ -1,0 +1,104 @@
+import { Component, Watch } from 'vue-property-decorator';
+import AppFormControlSelect from '../../form-vue/control/select/select.vue';
+import AppFormControlTextarea from '../../form-vue/control/textarea/textarea.vue';
+import AppFormControlTheme from '../../form-vue/control/theme/theme.vue';
+import { BaseForm } from '../../form-vue/form.service';
+import AppForm from '../../form-vue/form.vue';
+import AppFormGroup from '../../form-vue/group/group.vue';
+import { AppTheme } from '../theme';
+import { Theme } from '../theme.model';
+import { ThemeState, ThemeStore } from '../theme.store';
+import { AppThemeSvg } from './svg';
+
+interface VueColor {
+	hex: string | null;
+}
+
+const SvgList = [
+	require('../../../app/img/game-jolt-logo.svg'),
+	require('../../../app/img/game-jolt-client-logo.svg'),
+	require('../../../app/img/jolt.svg'),
+];
+
+const FillList = [
+	'fill-offset',
+	'fill-backdrop',
+	'fill-bg',
+	'fill-highlight',
+	'fill-notice',
+	'fill-gray',
+	'fill-dark',
+	'fill-darker',
+	'fill-darkest',
+	'fill-black',
+];
+
+@Component({
+	components: {
+		AppTheme,
+		AppThemeSvg,
+		AppForm,
+		AppFormGroup,
+		AppFormControlSelect,
+		AppFormControlTheme,
+		AppFormControlTextarea,
+	},
+})
+export default class AppThemeSvgStyleguide extends BaseForm<any> {
+	@ThemeState
+	theme!: ThemeStore['theme'];
+
+	customSvg = '';
+	customSelection: VueColor = { hex: null };
+
+	readonly SvgList = SvgList;
+	readonly FillList = FillList;
+
+	get formFile(): string {
+		return this.formModel.file || 'custom';
+	}
+
+	get formBgColor(): string {
+		return this.formModel.color || 'fill-offset';
+	}
+
+	get formTheme(): Theme | null {
+		return this.formModel.theme || this.theme;
+	}
+
+	get formCustomFile(): string {
+		return this.formModel.custom || '';
+	}
+
+	mounted() {
+		// Initialize the form fields
+		this.setField('file', this.formFile);
+		this.setField('color', this.formBgColor);
+		this.setField('theme', this.formTheme);
+		this.setField('custom', this.formCustomFile);
+	}
+
+	parseSvgName(name: string) {
+		try {
+			// This will remove '/assets/' and '.X.svg' from list names,
+			// leaving the plain filename without the file extension or path.
+			return name.split('/assets/')[1].split('.')[0];
+		} catch {
+			return name;
+		}
+	}
+
+	@Watch('formCustomFile')
+	onCustomSvgChange() {
+		// Reset and return if the textarea is empty.
+		if (!this.formCustomFile.length) {
+			return;
+		}
+
+		// Trim the satrt of the SVG string, otherwise we could have issues processing it.
+		const svgString = this.formCustomFile.trimStart();
+
+		// Parse the pasted SVG XML into a format that we can pass to AppThemeSvg.
+		this.customSvg = 'data:image/svg+xml;utf8,' + encodeURIComponent(svgString);
+	}
+}

--- a/src/_common/theme/svg/svg-styleguide.ts
+++ b/src/_common/theme/svg/svg-styleguide.ts
@@ -14,24 +14,12 @@ interface VueColor {
 	hex: string | null;
 }
 
-const SvgList = [
-	require('../../../app/img/game-jolt-logo.svg'),
-	require('../../../app/img/game-jolt-client-logo.svg'),
-	require('../../../app/img/jolt.svg'),
-];
-
-const FillList = [
-	'fill-offset',
-	'fill-backdrop',
-	'fill-bg',
-	'fill-highlight',
-	'fill-notice',
-	'fill-gray',
-	'fill-dark',
-	'fill-darker',
-	'fill-darkest',
-	'fill-black',
-];
+interface FormModel {
+	file?: string;
+	color?: string;
+	theme?: null | Theme;
+	custom?: string;
+}
 
 @Component({
 	components: {
@@ -44,38 +32,53 @@ const FillList = [
 		AppFormControlTextarea,
 	},
 })
-export default class AppThemeSvgStyleguide extends BaseForm<any> {
-	@ThemeState
-	theme!: ThemeStore['theme'];
+export default class AppThemeSvgStyleguide extends BaseForm<FormModel> {
+	@ThemeState('theme')
+	storeTheme!: ThemeStore['theme'];
 
 	customSvg = '';
 	customSelection: VueColor = { hex: null };
 
-	readonly SvgList = SvgList;
-	readonly FillList = FillList;
+	readonly SvgList = [
+		require('../../../app/img/game-jolt-logo.svg'),
+		require('../../../app/img/game-jolt-client-logo.svg'),
+		require('../../../app/img/jolt.svg'),
+	];
+	readonly FillList = [
+		'fill-offset',
+		'fill-backdrop',
+		'fill-bg',
+		'fill-highlight',
+		'fill-notice',
+		'fill-gray',
+		'fill-dark',
+		'fill-darker',
+		'fill-darkest',
+		'fill-black',
+	];
 
-	get formFile(): string {
+	get file() {
 		return this.formModel.file || 'custom';
 	}
 
-	get formBgColor(): string {
+	get bgColor() {
 		return this.formModel.color || 'fill-offset';
 	}
 
-	get formTheme(): Theme | null {
-		return this.formModel.theme || this.theme;
+	get theme() {
+		return this.formModel.theme || this.storeTheme;
 	}
 
-	get formCustomFile(): string {
+	get customFile() {
 		return this.formModel.custom || '';
 	}
 
 	mounted() {
 		// Initialize the form fields
-		this.setField('file', this.formFile);
-		this.setField('color', this.formBgColor);
-		this.setField('theme', this.formTheme);
-		this.setField('custom', this.formCustomFile);
+		this.setField('file', this.file);
+		this.setField('color', this.bgColor);
+		this.setField('theme', this.theme);
+		this.setField('custom', this.customFile);
 	}
 
 	parseSvgName(name: string) {
@@ -88,15 +91,15 @@ export default class AppThemeSvgStyleguide extends BaseForm<any> {
 		}
 	}
 
-	@Watch('formCustomFile')
+	@Watch('customFile')
 	onCustomSvgChange() {
 		// Reset and return if the textarea is empty.
-		if (!this.formCustomFile.length) {
+		if (!this.customFile.length) {
 			return;
 		}
 
-		// Trim the satrt of the SVG string, otherwise we could have issues processing it.
-		const svgString = this.formCustomFile.trimStart();
+		// Trim the start of the SVG string, otherwise we could have issues processing it.
+		const svgString = this.customFile.trimLeft();
 
 		// Parse the pasted SVG XML into a format that we can pass to AppThemeSvg.
 		this.customSvg = 'data:image/svg+xml;utf8,' + encodeURIComponent(svgString);

--- a/src/_common/theme/svg/svg-styleguide.vue
+++ b/src/_common/theme/svg/svg-styleguide.vue
@@ -1,0 +1,127 @@
+<template>
+	<app-theme :theme="formTheme">
+		<section id="styleguide-theme-svg" class="section">
+			<h1 class="section-header">Theme SVG</h1>
+
+			<p>
+				<translate>
+					See how our
+				</translate>
+				<code>.svg</code>
+				<translate>
+					files display on different background colors with different themes, or paste your own!
+				</translate>
+			</p>
+
+			<app-form name="theme-svg">
+				<div class="-selectors">
+					<!-- SVG File Selector -->
+					<app-form-group name="file" class="-selectors-item" :label="$gettext('Select SVG File')">
+						<app-form-control-select :disabled="!!formCustomFile.length">
+							<option value="custom">Custom SVG</option>
+
+							<template v-for="(path, key) of SvgList">
+								<option :key="key" :value="path">
+									<!-- Display just the name of the SVG file -->
+									{{ parseSvgName(path) }}
+								</option>
+							</template>
+						</app-form-control-select>
+					</app-form-group>
+
+					<!-- Background Color Selector -->
+					<app-form-group
+						name="color"
+						class="-selectors-item"
+						:label="$gettext('Select Background')"
+					>
+						<app-form-control-select placeholder="fill-what">
+							<template v-for="(color, key) of FillList">
+								<option :key="key" :value="color">
+									{{ color }}
+								</option>
+							</template>
+						</app-form-control-select>
+					</app-form-group>
+
+					<!-- Theme Selector -->
+					<app-form-group name="theme" class="-selectors-item" :label="$gettext('Select Theme')">
+						<app-form-control-theme class="-selectors-item-theme" />
+					</app-form-group>
+				</div>
+
+				<!-- Custom SVG Input -->
+				<app-form-group name="custom" class="-custom -selectors-item" hide-label>
+					<app-form-control-textarea
+						v-if="formFile === 'custom'"
+						class="-custom-input"
+						placeholder="Paste an SVG file..."
+					/>
+				</app-form-group>
+
+				<!-- Output Area -->
+				<div class="-output-area" :class="formBgColor">
+					<template v-if="formFile !== 'custom'">
+						<app-theme-svg :src="formFile" alt="" :theme="formTheme" />
+					</template>
+					<template v-else-if="!formCustomFile.length">
+						<translate class="text-muted">
+							Waiting for Custom SVG...
+						</translate>
+					</template>
+					<template v-else>
+						<app-theme-svg
+							:src="customSvg"
+							alt="Something is wrong with your SVG!"
+							:theme="formTheme"
+						/>
+					</template>
+				</div>
+			</app-form>
+		</section>
+	</app-theme>
+</template>
+
+<script lang="ts" src="./svg-styleguide"></script>
+
+<style lang="stylus" scoped>
+@require '~styles/variables'
+@require '~styles-lib/mixins'
+
+#styleguide-theme-svg
+	rounded-corners-lg()
+	change-bg('bg')
+	elevate-1()
+	border: $border-width-base solid var(--theme-bg-subtle)
+	padding-left: 20px
+	padding-right: 20px
+
+.-selectors
+	full-bleed()
+	display: flex
+
+	&-item
+		flex: 2
+		margin: 0 20px
+
+		&:last-of-type
+			flex: 1
+
+		&-theme
+			height: 20px
+
+.-custom
+	margin: 8px 0
+
+	&-input
+		height: 96px
+
+.-output-area
+	rounded-corners-lg()
+	display: flex
+	flex-flow: row wrap
+	justify-content: center
+	align-items: center
+	min-height: 300px
+	padding: 20px
+</style>

--- a/src/_common/theme/svg/svg-styleguide.vue
+++ b/src/_common/theme/svg/svg-styleguide.vue
@@ -1,51 +1,39 @@
 <template>
-	<app-theme :theme="formTheme">
+	<app-theme :theme="theme">
 		<section id="styleguide-theme-svg" class="section">
 			<h1 class="section-header">Theme SVG</h1>
 
 			<p>
-				<translate>
-					See how our
-				</translate>
-				<code>.svg</code>
-				<translate>
-					files display on different background colors with different themes, or paste your own!
-				</translate>
+				See how our
+				<code>svg</code>
+				files display on different background colors with different themes, or paste your own!
 			</p>
 
 			<app-form name="theme-svg">
 				<div class="-selectors">
 					<!-- SVG File Selector -->
-					<app-form-group name="file" class="-selectors-item" :label="$gettext('Select SVG File')">
-						<app-form-control-select :disabled="!!formCustomFile.length">
+					<app-form-group name="file" class="-selectors-item" label="Select SVG File">
+						<app-form-control-select :disabled="!!customFile.length">
 							<option value="custom">Custom SVG</option>
 
-							<template v-for="(path, key) of SvgList">
-								<option :key="key" :value="path">
-									<!-- Display just the name of the SVG file -->
-									{{ parseSvgName(path) }}
-								</option>
-							</template>
+							<option v-for="(path, key) of SvgList" :key="key" :value="path">
+								<!-- Display just the name of the SVG file -->
+								{{ parseSvgName(path) }}
+							</option>
 						</app-form-control-select>
 					</app-form-group>
 
 					<!-- Background Color Selector -->
-					<app-form-group
-						name="color"
-						class="-selectors-item"
-						:label="$gettext('Select Background')"
-					>
-						<app-form-control-select placeholder="fill-what">
-							<template v-for="(color, key) of FillList">
-								<option :key="key" :value="color">
-									{{ color }}
-								</option>
-							</template>
+					<app-form-group name="color" class="-selectors-item" label="Select Background">
+						<app-form-control-select placeholder="Fill Color">
+							<option v-for="(color, key) of FillList" :key="key" :value="color">
+								{{ color }}
+							</option>
 						</app-form-control-select>
 					</app-form-group>
 
 					<!-- Theme Selector -->
-					<app-form-group name="theme" class="-selectors-item" :label="$gettext('Select Theme')">
+					<app-form-group name="theme" class="-selectors-item" label="Select Theme">
 						<app-form-control-theme class="-selectors-item-theme" />
 					</app-form-group>
 				</div>
@@ -53,28 +41,24 @@
 				<!-- Custom SVG Input -->
 				<app-form-group name="custom" class="-custom -selectors-item" hide-label>
 					<app-form-control-textarea
-						v-if="formFile === 'custom'"
-						class="-custom-input"
+						v-if="file === 'custom'"
 						placeholder="Paste an SVG file..."
+						rows="6"
 					/>
 				</app-form-group>
 
 				<!-- Output Area -->
-				<div class="-output-area" :class="formBgColor">
-					<template v-if="formFile !== 'custom'">
-						<app-theme-svg :src="formFile" alt="" :theme="formTheme" />
+				<div class="-output-area" :class="bgColor">
+					<template v-if="file !== 'custom'">
+						<app-theme-svg :src="file" :theme="theme" inpage />
 					</template>
-					<template v-else-if="!formCustomFile.length">
-						<translate class="text-muted">
+					<template v-else-if="!customFile.length">
+						<span class="text-muted">
 							Waiting for Custom SVG...
-						</translate>
+						</span>
 					</template>
 					<template v-else>
-						<app-theme-svg
-							:src="customSvg"
-							alt="Something is wrong with your SVG!"
-							:theme="formTheme"
-						/>
+						<app-theme-svg :src="customSvg" :theme="theme" inpage />
 					</template>
 				</div>
 			</app-form>
@@ -91,7 +75,6 @@
 #styleguide-theme-svg
 	rounded-corners-lg()
 	change-bg('bg')
-	elevate-1()
 	border: $border-width-base solid var(--theme-bg-subtle)
 	padding-left: 20px
 	padding-right: 20px
@@ -112,9 +95,6 @@
 
 .-custom
 	margin: 8px 0
-
-	&-input
-		height: 96px
 
 .-output-area
 	rounded-corners-lg()

--- a/src/_common/theme/svg/svg.ts
+++ b/src/_common/theme/svg/svg.ts
@@ -12,20 +12,16 @@ const SvgGraysRegex: RegExp = /#([a-f\d]{1,2})\1{2}\b/gi;
 
 @Component({})
 export class AppThemeSvg extends Vue {
-	@Prop(String)
-	src!: string;
+	@Prop(propOptional(String, '')) src!: string;
+	@Prop(propOptional(Theme, null)) theme!: null | Theme;
 
-	@Prop(propOptional(Theme, null))
-	theme!: null | Theme;
-
-	@ThemeState('theme')
-	defaultTheme!: ThemeStore['theme'];
+	@ThemeState('theme') storeTheme!: ThemeStore['theme'];
 
 	rawSvg = '';
 	request?: Promise<any>;
 
 	get actualTheme() {
-		return this.theme || this.defaultTheme;
+		return this.theme || this.storeTheme;
 	}
 
 	get processedSvg() {

--- a/src/_common/theme/svg/svg.ts
+++ b/src/_common/theme/svg/svg.ts
@@ -3,18 +3,30 @@ import { darken, lighten, parseToHsl } from 'polished';
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { CreateElement } from 'vue/types/vue';
+import { arrayUnique } from '../../../utils/array';
+import { propOptional } from '../../../utils/vue';
+import { Theme } from '../theme.model';
 import { ThemeState, ThemeStore } from '../theme.store';
+
+const SvgGraysRegex: RegExp = /#([a-f\d]{1,2})\1{2}\b/gi;
 
 @Component({})
 export class AppThemeSvg extends Vue {
 	@Prop(String)
 	src!: string;
 
-	@ThemeState
-	theme!: ThemeStore['theme'];
+	@Prop(propOptional(Theme, null))
+	theme!: null | Theme;
+
+	@ThemeState('theme')
+	defaultTheme!: ThemeStore['theme'];
 
 	rawSvg = '';
 	request?: Promise<any>;
+
+	get actualTheme() {
+		return this.theme || this.defaultTheme;
+	}
 
 	get processedSvg() {
 		if (GJ_IS_SSR) {
@@ -23,13 +35,13 @@ export class AppThemeSvg extends Vue {
 
 		let svgData = this.rawSvg;
 
-		if (this.theme) {
-			let highlight = '#' + this.theme.highlight;
-			let backlight = '#' + this.theme.backlight;
-			let notice = '#' + this.theme.notice;
+		if (this.actualTheme) {
+			let highlight = '#' + this.actualTheme.highlight;
+			let backlight = '#' + this.actualTheme.backlight;
+			let notice = '#' + this.actualTheme.notice;
 
-			if (this.theme.custom) {
-				const highlight_ = '#' + this.theme.highlight_;
+			if (this.actualTheme.custom) {
+				const highlight_ = '#' + this.actualTheme.highlight_;
 				const hsl = parseToHsl(highlight_);
 				if (hsl.lightness < 0.4) {
 					highlight = lighten(0.3, highlight_);
@@ -41,7 +53,21 @@ export class AppThemeSvg extends Vue {
 				notice = highlight;
 			}
 
-			svgData = svgData
+			// Process svgData as a String so we don't throw errors in the
+			// ThemeSvg styleguide if the custom svg string is a number.
+			let grays = String(svgData).match(SvgGraysRegex);
+
+			if (grays) {
+				grays = arrayUnique(grays);
+
+				for (const gray of grays) {
+					svgData = svgData.replace(gray, '#' + this.actualTheme.tintColor(gray, 0.04));
+				}
+			}
+
+			// Same as above, need to convert svgData to a string in case
+			// the custom svg input from the ThemeSvg styleguide is a number.
+			svgData = String(svgData)
 				.replace(/\#ccff00/gi, highlight)
 				.replace(/\#cf0/gi, highlight)
 				.replace(/\#2f7f6f/gi, backlight)

--- a/src/_common/theme/theme.model.ts
+++ b/src/_common/theme/theme.model.ts
@@ -322,7 +322,7 @@ export class Theme extends Model {
 		return getReadableCustom(this.custom, 'light');
 	}
 
-	private tintColor(color: string, amount: number) {
+	tintColor(color: string, amount: number) {
 		return (this.tint_ ? mix(amount, '#' + this.tint_, color) : color).substr(1);
 	}
 }

--- a/src/app/views/styleguide/styleguide.ts
+++ b/src/app/views/styleguide/styleguide.ts
@@ -6,6 +6,7 @@ import AppProgressBarStyleguide from '../../../_common/progress/bar/bar-stylegui
 import { BaseRouteComponent, RouteResolver } from '../../../_common/route/route-component';
 import AppScrollAffix from '../../../_common/scroll/affix/affix.vue';
 import { AppScrollTo } from '../../../_common/scroll/to/to.directive';
+import AppThemeSvgStyleguide from '../../../_common/theme/svg/svg-styleguide.vue';
 import { User } from '../../../_common/user/user.model';
 import AppStyleguideColor from './color/color.vue';
 
@@ -16,8 +17,9 @@ import AppStyleguideColor from './color/color.vue';
 		AppButtonStyleguide,
 		AppListGroupStyleguide,
 		AppProgressBarStyleguide,
-		AppJolticonsStyleguide,
 		AppStyleguideColor,
+		AppThemeSvgStyleguide,
+		AppJolticonsStyleguide,
 	},
 	directives: {
 		AppScrollTo,
@@ -38,6 +40,7 @@ export default class RouteStyleguide extends BaseRouteComponent {
 			'list-groups': 'List Groups',
 			'progress-bars': 'Progress Bars',
 			colors: 'Colors',
+			'theme-svg': 'Theme SVG',
 			jolticons: 'Jolticons',
 		};
 	}
@@ -48,6 +51,7 @@ export default class RouteStyleguide extends BaseRouteComponent {
 			AppListGroupStyleguide,
 			AppProgressBarStyleguide,
 			AppStyleguideColor,
+			AppThemeSvgStyleguide,
 			AppJolticonsStyleguide,
 		];
 	}


### PR DESCRIPTION
Add a section to the styleguide that allows you to paste svg xml, displaying it through `AppThemeSvg`.

Has options to change the fill-class and theme of the display area so we can see how current/new/potential svg files look in different display contexts.