### PR TITLE
Fix cbar item notification counts blocking link

### DIFF
--- a/src/app/components/shell/cbar/item/item.vue
+++ b/src/app/components/shell/cbar/item/item.vue
@@ -33,6 +33,9 @@ $-blip-top = $-item-size * 0.5 - $-blip-size * 0.5
 	width: $-item-size - 2px
 	height: $-item-size - 2px
 
+.-blip, .-notification-count
+	pointer-events: none
+
 .-blip
 	position: absolute
 	width: $-blip-size


### PR DESCRIPTION
also removes pointer-events on the blip, since clicking that does nothing anyway