### PR TITLE
Fix mailto links breaking under certain conditions

### DIFF
--- a/src/_common/contact-link/contact-link.ts
+++ b/src/_common/contact-link/contact-link.ts
@@ -1,0 +1,16 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { propRequired } from '../../utils/vue';
+import { Navigate } from '../navigate/navigate.service';
+
+@Component({})
+export default class AppContactLink extends Vue {
+	@Prop(propRequired(String)) email!: string;
+
+	onClick() {
+		// Sometimes Vue router will break <a> tags that use mailto
+		// by replacing part of the current url with the mailto path,
+		// so we can instead use 'Navigate.goto(path)' to bypass this.
+		Navigate.goto(`mailto:${this.email}`);
+	}
+}

--- a/src/_common/contact-link/contact-link.vue
+++ b/src/_common/contact-link/contact-link.vue
@@ -1,0 +1,7 @@
+<template>
+	<a :title="email" @click="onClick()">
+		<slot />
+	</a>
+</template>
+
+<script lang="ts" src="./contact-link"></script>

--- a/src/app/components/shell/footer/footer.ts
+++ b/src/app/components/shell/footer/footer.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
+import AppContactLink from '../../../../_common/contact-link/contact-link.vue';
 import { date } from '../../../../_common/filters/date';
-import { Navigate } from '../../../../_common/navigate/navigate.service';
 import { Screen } from '../../../../_common/screen/screen-service';
 import { AppThemeSvg } from '../../../../_common/theme/svg/svg';
 import AppTranslateLangSelector from '../../../../_common/translate/lang-selector/lang-selector.vue';
@@ -16,6 +16,7 @@ if (GJ_IS_CLIENT) {
 	components: {
 		AppTranslateLangSelector,
 		AppThemeSvg,
+		AppContactLink,
 	},
 	filters: {
 		date,
@@ -33,12 +34,5 @@ export default class AppShellFooter extends Vue {
 		if (ClientSystemReportModalMod) {
 			ClientSystemReportModalMod.ClientSystemReportModal.show();
 		}
-	}
-
-	onClickEmail() {
-		// If the <a> tag has the mailto in its href attribute,
-		// on certain pages the Vue router replaces part of the url with the email address,
-		// instead of redirecting to the mailto application.
-		Navigate.goto('mailto:contact@gamejolt.com');
 	}
 }

--- a/src/app/components/shell/footer/footer.vue
+++ b/src/app/components/shell/footer/footer.vue
@@ -104,9 +104,9 @@
 						<div class="col-xs-4 col-sm-3">
 							<ol class="list-unstyled footer-link-list">
 								<li>
-									<a @click="onClickEmail" title="contact@gamejolt.com">
+									<app-contact-link email="contact@gamejolt.com">
 										<translate>footer.contact</translate>
-									</a>
+									</app-contact-link>
 								</li>
 								<li>
 									<router-link :to="{ name: 'legal.terms' }">

--- a/src/app/views/landing/about/about.ts
+++ b/src/app/views/landing/about/about.ts
@@ -1,13 +1,15 @@
+import { Component } from 'vue-property-decorator';
+import { importContext } from '../../../../utils/utils';
+import AppContactLink from '../../../../_common/contact-link/contact-link.vue';
 import { BaseRouteComponent } from '../../../../_common/route/route-component';
 import { Screen } from '../../../../_common/screen/screen-service';
 import { AppThemeSvg } from '../../../../_common/theme/svg/svg';
-import { importContext } from '../../../../utils/utils';
-import { Component } from 'vue-property-decorator';
 
 @Component({
 	name: 'RouteLandingAbout',
 	components: {
 		AppThemeSvg,
+		AppContactLink,
 	},
 })
 export default class RouteLandingAbout extends BaseRouteComponent {

--- a/src/app/views/landing/about/about.vue
+++ b/src/app/views/landing/about/about.vue
@@ -80,14 +80,18 @@
 								, check out the
 								<router-link :to="{ name: 'forums.landing.overview' }">forums</router-link>
 								or email us at
-								<a href="mailto:contact@gamejolt.com">contact@gamejolt.com</a>
+								<app-contact-link email="contact@gamejolt.com">
+									contact@gamejolt.com
+								</app-contact-link>
 								.
 							</p>
 
 							<p>
 								<strong>Press/business inquiries</strong>
 								email Yaprak DeCarmine at
-								<a href="mailto:yaprak@gamejolt.com">yaprak@gamejolt.com</a>
+								<app-contact-link email="yaprak@gamejolt.com">
+									yaprak@gamejolt.com
+								</app-contact-link>
 								.
 							</p>
 						</div>

--- a/src/app/views/landing/marketplace/marketplace.ts
+++ b/src/app/views/landing/marketplace/marketplace.ts
@@ -1,6 +1,7 @@
 import { Component } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { Api } from '../../../../_common/api/api.service';
+import AppContactLink from '../../../../_common/contact-link/contact-link.vue';
 import { FiresidePost } from '../../../../_common/fireside/post/post-model';
 import { Game } from '../../../../_common/game/game.model';
 import AppGameThumbnail from '../../../../_common/game/thumbnail/thumbnail.vue';
@@ -17,6 +18,7 @@ import { Store } from '../../../store/index';
 		AppGameThumbnail,
 		AppAuthJoin: AppAuthJoinLazy,
 		AppThemeSvg,
+		AppContactLink,
 	},
 })
 @RouteResolver({

--- a/src/app/views/landing/marketplace/marketplace.vue
+++ b/src/app/views/landing/marketplace/marketplace.vue
@@ -219,7 +219,9 @@
 
 							<p class="text-muted text-center">
 								Or
-								<a href="mailto:contact@gamejolt.com">contact us</a>
+								<app-contact-link email="contact@gamejolt.com">
+									contact us
+								</app-contact-link>
 								if you have questions!
 							</p>
 						</div>

--- a/src/checkout/app.ts
+++ b/src/checkout/app.ts
@@ -4,6 +4,7 @@ import { State } from 'vuex-class';
 import { loadCurrentLanguage } from '../utils/translations';
 import * as _ClientHistoryNavigatorMod from '../_common/client/history-navigator/history-navigator.service';
 import { Connection } from '../_common/connection/connection-service';
+import AppContactLink from '../_common/contact-link/contact-link.vue';
 import AppCookieBanner from '../_common/cookie/banner/banner.vue';
 import { Environment } from '../_common/environment/environment.service';
 import AppErrorPage from '../_common/error/page/page.vue';
@@ -18,6 +19,7 @@ let components: any = {
 	AppErrorPage,
 	AppUserBar,
 	AppCookieBanner,
+	AppContactLink,
 };
 
 let ClientHistoryNavigatorMod: typeof _ClientHistoryNavigatorMod | undefined;

--- a/src/checkout/app.vue
+++ b/src/checkout/app.vue
@@ -25,7 +25,7 @@
 				<div class="row">
 					<div class="col-sm-6">
 						<p class="footer-links">
-							<a href="mailto:contact@gamejolt.com">Contact Game Jolt</a>
+							<app-contact-link email="contact@gamejolt.com">Contact Game Jolt</app-contact-link>
 							&nbsp; | &nbsp;
 							<a :href="Environment.baseUrl + '/terms'" target="_blank">Terms</a>
 							&nbsp; | &nbsp;

--- a/src/claim/app.ts
+++ b/src/claim/app.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { loadCurrentLanguage } from '../utils/translations';
+import AppContactLink from '../_common/contact-link/contact-link.vue';
 import AppCookieBanner from '../_common/cookie/banner/banner.vue';
 import { Environment } from '../_common/environment/environment.service';
 import AppErrorPage from '../_common/error/page/page.vue';
@@ -17,6 +18,7 @@ import { Store } from './store/index';
 		AppErrorPage,
 		AppUserBar,
 		AppCookieBanner,
+		AppContactLink,
 	},
 	filters: {
 		date,

--- a/src/claim/app.vue
+++ b/src/claim/app.vue
@@ -19,7 +19,7 @@
 				<div class="row">
 					<div class="col-sm-6">
 						<p class="footer-links">
-							<a href="mailto:contact@gamejolt.com">Contact Game Jolt</a>
+							<app-contact-link email="contact@gamejolt.com">Contact Game Jolt</app-contact-link>
 							&nbsp; | &nbsp;
 							<a :href="Environment.baseUrl + '/terms'" target="_blank">Terms</a>
 							&nbsp; | &nbsp;


### PR DESCRIPTION
Created a new `AppContactLink` common component that should be wrapped around any `mailto:foo@bar.baz` links.

Just pass an `email` prop with the email address, and the component will add the `mailto:` prefix and add the email address as a title to the`<a>` tag wrapping the slot.