### PR TITLE
Allow no-speed swipes on posts, lower needed speed

### DIFF
--- a/src/app/components/activity/feed/devlog-post/media/media.ts
+++ b/src/app/components/activity/feed/devlog-post/media/media.ts
@@ -132,10 +132,16 @@ export default class AppActivityFeedDevlogPostMedia extends Vue implements Light
 	panEnd(event: HammerInput) {
 		this.isDragging = false;
 
-		// Make sure we moved at a high enough velocity and distance to register the "swipe".
-		const velocity = event.velocityX;
-		if (Math.abs(velocity) > 0.65 && event.distance > 10) {
-			if (velocity > 0) {
+		// Make sure we moved at a high enough velocity and/or distance to register the "swipe".
+		const { velocityX, deltaX } = event;
+
+		if (
+			// Check if it was a fast flick,
+			(Math.abs(velocityX) > 0.55 && event.distance > 10) ||
+			// or if the pan distance was at least ~1/3 of the content area.
+			Math.abs(deltaX) >= this.$el.clientWidth / 3
+		) {
+			if (velocityX > 0 || deltaX > 0) {
 				this.goPrev();
 			} else {
 				this.goNext();

--- a/src/app/components/activity/feed/devlog-post/media/media.ts
+++ b/src/app/components/activity/feed/devlog-post/media/media.ts
@@ -133,11 +133,11 @@ export default class AppActivityFeedDevlogPostMedia extends Vue implements Light
 		this.isDragging = false;
 
 		// Make sure we moved at a high enough velocity and/or distance to register the "swipe".
-		const { velocityX, deltaX } = event;
+		const { velocityX, deltaX, distance } = event;
 
 		if (
 			// Check if it was a fast flick,
-			(Math.abs(velocityX) > 0.55 && event.distance > 10) ||
+			(Math.abs(velocityX) > 0.55 && distance > 10) ||
 			// or if the pan distance was at least ~1/3 of the content area.
 			Math.abs(deltaX) >= this.$el.clientWidth / 3
 		) {


### PR DESCRIPTION
Lowers the required velocity from 0.65 to 0.55, and allows swiping to the next post if dragging the post ~1/3 of the way - regardless of speed.