### PR TITLE
Fix EventItemControlsOverlay padding issues

### DIFF
--- a/src/_common/event-item/controls-overlay/controls-overlay.vue
+++ b/src/_common/event-item/controls-overlay/controls-overlay.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="-container">
-		<div class="-overlay" :class="{ '-end': end }" />
+	<div class="-controls">
+		<div class="-controls-overlay" :class="{ '-end': end }" />
 		<slot />
 	</div>
 </template>
@@ -11,28 +11,28 @@
 @require '~styles/variables'
 @require '~styles-lib/mixins'
 
-.-container
+.-controls
 	position: relative
 	// Needs to be higher than the z-index of AppStickerTarget
 	z-index: 1
 
-.-overlay
-	change-bg('bg')
-	position: absolute
-	top: -4px
-	right: 0
-	bottom: 4px
-	left: 0
-	opacity: 0.9
-	z-index: -1
-	// We want to expand the overlay out to the edges of the post container.
-	margin-left: -($grid-gutter-width-xs / 2)
-	margin-right: -($grid-gutter-width-xs / 2)
+	&-overlay
+		change-bg('bg')
+		position: absolute
+		top: -4px
+		right: 0
+		bottom: 4px
+		left: 0
+		opacity: 0.9
+		z-index: -1
+		// We want to expand the overlay out to the edges of the post container.
+		margin-left: -($grid-gutter-width-xs / 2)
+		margin-right: -($grid-gutter-width-xs / 2)
 
-	@media $media-sm-up
-		margin-left: -($grid-gutter-width / 2) + $border-width-base + 0.5px
-		margin-right: -($grid-gutter-width / 2) + $border-width-base + 0.5px
+		@media $media-sm-up
+			margin-left: -($grid-gutter-width / 2) + $border-width-base + 0.5px
+			margin-right: -($grid-gutter-width / 2) + $border-width-base + 0.5px
 
-	&.-end
-		bottom: -4px
+		&.-end
+			bottom: -4px
 </style>

--- a/src/_common/event-item/controls-overlay/controls-overlay.vue
+++ b/src/_common/event-item/controls-overlay/controls-overlay.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="-controls">
-		<div class="-controls-overlay" :class="{ '-end': end }" />
+	<div class="event-item-controls-overlay">
+		<div class="-overlay" :class="{ '-end': end }" />
 		<slot />
 	</div>
 </template>
@@ -11,12 +11,12 @@
 @require '~styles/variables'
 @require '~styles-lib/mixins'
 
-.-controls
+.event-item-controls-overlay
 	position: relative
 	// Needs to be higher than the z-index of AppStickerTarget
 	z-index: 1
 
-	&-overlay
+	.-overlay
 		change-bg('bg')
 		position: absolute
 		top: -4px


### PR DESCRIPTION
Rename class names to resolve issues with `AppEventItemControlsOverlay` getting padding styling from its parent.