### PR TITLE
Change post slider control colors

### DIFF
--- a/src/app/components/activity/feed/devlog-post/media/media.styl
+++ b/src/app/components/activity/feed/devlog-post/media/media.styl
@@ -50,7 +50,6 @@ $-button-size = 60px
 	> .jolticon
 		vertical-align: middle
 		font-size: ($-button-size / 2)
-		color: $white
 
 .-prev
 	left: -($-item-padding-container)

--- a/src/app/components/activity/feed/devlog-post/media/media.styl
+++ b/src/app/components/activity/feed/devlog-post/media/media.styl
@@ -41,7 +41,6 @@ $-button-size = 60px
 	margin-top: -(@height / 2)
 	text-align: center
 	z-index: 2
-	background-color: rgba($black, 0.25)
 	transition: opacity 0.2s ease
 
 	// Hide and disable slider controls for mobile devices
@@ -52,9 +51,6 @@ $-button-size = 60px
 		vertical-align: middle
 		font-size: ($-button-size / 2)
 		color: $white
-
-	&:hover
-		background-color: rgba($black, 0.5)
 
 .-prev
 	left: -($-item-padding-container)

--- a/src/app/components/activity/feed/devlog-post/media/media.vue
+++ b/src/app/components/activity/feed/devlog-post/media/media.vue
@@ -27,7 +27,13 @@
 				<app-jolticon icon="chevron-left" />
 			</app-button>
 
-			<app-button class="-next" v-if="page < post.media.length" overlay trans @click.stop="goNext">
+			<app-button
+				class="-next"
+				v-if="page < post.media.length"
+				overlay
+				trans
+				@click.stop="goNext"
+			>
 				<app-jolticon icon="chevron-right" />
 			</app-button>
 		</v-touch>

--- a/src/app/components/activity/feed/devlog-post/media/media.vue
+++ b/src/app/components/activity/feed/devlog-post/media/media.vue
@@ -23,13 +23,13 @@
 				</div>
 			</div>
 
-			<a class="-prev" v-if="page > 1" @click.stop="goPrev">
+			<app-button class="-prev" v-if="page > 1" overlay trans @click="goPrev">
 				<app-jolticon icon="chevron-left" />
-			</a>
+			</app-button>
 
-			<a class="-next" v-if="page < post.media.length" @click.stop="goNext">
+			<app-button class="-next" v-if="page < post.media.length" overlay trans @click="goNext">
 				<app-jolticon icon="chevron-right" />
-			</a>
+			</app-button>
 		</v-touch>
 
 		<app-event-item-media-indicator

--- a/src/app/components/activity/feed/devlog-post/media/media.vue
+++ b/src/app/components/activity/feed/devlog-post/media/media.vue
@@ -23,11 +23,11 @@
 				</div>
 			</div>
 
-			<app-button class="-prev" v-if="page > 1" overlay trans @click="goPrev">
+			<app-button class="-prev" v-if="page > 1" overlay trans @click.stop="goPrev">
 				<app-jolticon icon="chevron-left" />
 			</app-button>
 
-			<app-button class="-next" v-if="page < post.media.length" overlay trans @click="goNext">
+			<app-button class="-next" v-if="page < post.media.length" overlay trans @click.stop="goNext">
 				<app-jolticon icon="chevron-right" />
 			</app-button>
 		</v-touch>


### PR DESCRIPTION
Use `AppButton` styling to stay consistent with the fullscreen button toolbar on post items.