### PR TITLE
Add mobile drag delay for media-bar items

### DIFF
--- a/src/_common/card/list/draggable/draggable.vue
+++ b/src/_common/card/list/draggable/draggable.vue
@@ -1,5 +1,8 @@
 <template>
-	<draggable v-model="items" :options="{ handle: '.card-drag-handle' }">
+	<draggable
+		v-model="items"
+		:options="{ handle: '.card-drag-handle', delay: 100, delayOnTouchOnly: true }"
+	>
 		<slot />
 	</draggable>
 </template>

--- a/src/app/components/forms/post/_media/item/item.vue
+++ b/src/app/components/forms/post/_media/item/item.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="-item" :style="{ width, height }">
 		<div class="-controls theme-dark">
-			<app-button icon="remove" overlay sparse @click="emitRemove()" />
+			<app-button icon="remove" overlay sparse @click.capture="emitRemove()" />
 		</div>
 
 		<app-img-responsive :src="item.mediaserver_url" alt="" />

--- a/src/app/components/forms/post/_media/media.vue
+++ b/src/app/components/forms/post/_media/media.vue
@@ -39,7 +39,11 @@
 							</div>
 						</a>
 
-						<draggable style="display: inline-flex" v-model="internalItems">
+						<draggable
+							style="display: inline-flex"
+							v-model="internalItems"
+							:options="{ delay: 100, delayOnTouchOnly: true }"
+						>
 							<div class="-item" v-for="item of internalItems" :key="item.id">
 								<app-form-post-media-item :item="item" @remove="emitRemove(item)" />
 							</div>

--- a/src/app/views/dashboard/games/manage/game/_media-bar/media-bar.vue
+++ b/src/app/views/dashboard/games/manage/game/_media-bar/media-bar.vue
@@ -19,7 +19,11 @@
 				</div>
 			</a>
 
-			<draggable style="display: inline-flex" v-model="draggableItems">
+			<draggable
+				style="display: inline-flex"
+				v-model="draggableItems"
+				:options="{ delay: 100, delayOnTouchOnly: true }"
+			>
 				<div v-for="item of draggableItems" :key="item.id">
 					<app-game-media-bar-item class="-item" :item="item" @click.native="open(item)">
 						<app-editable-overlay class="-item-hover hidden-xs" @click="open(item)">


### PR DESCRIPTION
Added a delay for touch devices dragging items within the `draggable` component, requiring a static hold for at least `100ms` before being able to drag a draggable items, and set the click listeners for removing media-bar items to `capture`.

This should fix the issue of being unable to remove media-bar items on mobile, but it's hard to test with just touch emulation.

The drag delay should also help the mobile experience with these components, allowing swipes on media items to scroll through them without re-sorting them.