### PR TITLE
Add invisible placeholder for post slider controls

### DIFF
--- a/src/app/components/activity/feed/devlog-post/media/media.vue
+++ b/src/app/components/activity/feed/devlog-post/media/media.vue
@@ -26,6 +26,7 @@
 			<app-button class="-prev" v-if="page > 1" overlay trans @click.stop="goPrev">
 				<app-jolticon icon="chevron-left" />
 			</app-button>
+			<div v-else-if="post.media.length > 1" class="-prev" @click.stop></div>
 
 			<app-button
 				class="-next"
@@ -36,6 +37,7 @@
 			>
 				<app-jolticon icon="chevron-right" />
 			</app-button>
+			<div v-else-if="post.media.length > 1" class="-next" @click.stop></div>
 		</v-touch>
 
 		<app-event-item-media-indicator


### PR DESCRIPTION
The placeholder only appears when there's more than one post to swipe through, and replaces the missing `prev` and `next` button when they disappear at the start and end of the post items.

This will help prevent unintentional clicks into the post.