### PR TITLE
Fix being unable to edit bio in onboarding process

### DIFF
--- a/src/app/components/forms/onboarding/profile/profile.styl
+++ b/src/app/components/forms/onboarding/profile/profile.styl
@@ -42,7 +42,6 @@
 			position: relative
 			width: 100%
 			flex: auto
-			//
 			display: flex
 			align-items: center
 
@@ -53,6 +52,12 @@
 			input
 				padding-left: 23px
 				display: inline-block
+
+.-bio-input
+	text-align: left
+
+	&-placeholder
+		min-height: ($line-height-computed + 22)
 
 >>> .form-group
 	margin-bottom: 0

--- a/src/app/components/forms/onboarding/profile/profile.vue
+++ b/src/app/components/forms/onboarding/profile/profile.vue
@@ -44,13 +44,15 @@
 			<section class="-bio">
 				<app-form-group name="bio" optional hide-label>
 					<app-form-control-content
-						style="text-align: left;"
+						v-if="isLoaded"
+						class="-bio-input anim-fade-in"
 						content-context="user-bio"
 						:disabled="!allowBioChange"
 						:model-id="user.id"
 						:placeholder="$gettext(`Tell people about yourself`)"
 						:max-height="0"
 					/>
+					<div v-else class="-bio-input-placeholder" />
 				</app-form-group>
 			</section>
 

--- a/src/app/views/welcome/welcome.ts
+++ b/src/app/views/welcome/welcome.ts
@@ -36,12 +36,7 @@ export default class RouteWelcome extends BaseRouteComponent {
 	}
 
 	routeCreated() {
-		// Since the app section and auth section may run on different ports
-		// the local storage key used to start the onboarding flow might not be available.
-		// This allows us to test in dev.
-		if (GJ_ENVIRONMENT === 'development') {
-			Onboarding.start();
-		}
+		Onboarding.start();
 
 		if (!Onboarding.isOnboarding) {
 			this.$router.push({ name: 'home' });


### PR DESCRIPTION
Render in the content-editor for the bio creation once we set the condition for if it's disabled or not, and have an empty placeholder of the same height until things are loaded in.