### PR TITLE
Fix retrieve translation text

### DIFF
--- a/src/claim/views/retrieve/retrieve.vue
+++ b/src/claim/views/retrieve/retrieve.vue
@@ -17,11 +17,11 @@
 					<translate>Please enter your email address to retrieve your keys.</translate>
 				</template>
 				<template v-if="resourceTitle">
-					<translate :translate-params="{ resource: resourceTitle }">
+					<span v-translate="{ resource: resourceTitle }">
 						Please enter your email address to retrieve your keys for
 						<b>%{ resource }</b>
 						.
-					</translate>
+					</span>
 				</template>
 				<translate>We will email you a link to your download(s).</translate>
 			</p>


### PR DESCRIPTION
We are basically injecting ourselves with HTML here, which we fixed.
Use v-translate instead of `<translate>` to circumvent this.