### PR TITLE
Generate one system notification for chat messages

### DIFF
--- a/src/app/components/chat/notification-growl/notification-growl.service.ts
+++ b/src/app/components/chat/notification-growl/notification-growl.service.ts
@@ -13,7 +13,7 @@ export class ChatNotificationGrowl {
 
 		Growls.info({
 			onclick: () => enterChatRoom(chat, message.room_id),
-			system: true,
+			system: chat.userChannel?.elector.isLeader,
 
 			title: `💬 ${message.user.display_name} (@${message.user.username})`,
 			message: this.generateSystemMessage(message),

--- a/src/app/components/chat/user-channel.ts
+++ b/src/app/components/chat/user-channel.ts
@@ -21,9 +21,9 @@ interface ClearNotificationsPayload {
 export class ChatUserChannel extends Channel {
 	readonly client: ChatClient;
 	readonly socket: Socket;
+	readonly elector: LeaderElector;
 
 	private notificationChannel: BroadcastChannel;
-	private elector: LeaderElector;
 
 	constructor(userId: number, client: ChatClient, params?: any) {
 		super('user:' + userId, params, client.socket as Socket);
@@ -118,9 +118,7 @@ export class ChatUserChannel extends Channel {
 			this.client.friendsList.update(friend);
 		}
 
-		if (this.elector.isLeader) {
-			ChatNotificationGrowl.show(this.client, message);
-		}
+		ChatNotificationGrowl.show(this.client, message);
 	}
 
 	private onYouUpdated(data: Partial<ChatUser>) {


### PR DESCRIPTION
Fix so all tabs show a notification in-page, but only spawn one system notification.