### PR TITLE
Fix border issues with user-cards

### DIFF
--- a/src/_common/user/card/card.styl
+++ b/src/_common/user/card/card.styl
@@ -1,10 +1,13 @@
-@require '~styles/variables'
-@require '~styles-lib/mixins'
+@import '~styles/variables'
+@import '~styles-lib/mixins'
 
 .user-card
 	rounded-corners-lg()
 	margin-bottom: $line-height-computed
 	overflow: hidden
+
+	.popper-content &
+		border: 0
 
 .-well
 	position: relative


### PR DESCRIPTION
removes the borders from user-cards when they are contained within a popper