### PR TITLE
Fix leaving group rooms

### DIFF
--- a/src/app/components/chat/client.ts
+++ b/src/app/components/chat/client.ts
@@ -665,10 +665,9 @@ export function addGroupMembers(chat: ChatClient, roomId: number, members: numbe
 	return chat.roomChannels[roomId].push('member_add', { member_ids: members });
 }
 
-export function leaveGroupRoom(chat: ChatClient) {
-	const room = chat.room;
-	if (room) {
-		chat.roomChannels[room.id].push('group_leave', {}).receive('ok', _response => {
+export async function leaveGroupRoom(chat: ChatClient, room: ChatRoom) {
+	if (room.isGroupRoom) {
+		chat.userChannel?.push('group_leave', { room_id: room.id }).receive('ok', _response => {
 			if (isInChatRoom(chat, room.id)) {
 				leaveChatRoom(chat);
 			}

--- a/src/app/components/chat/client.ts
+++ b/src/app/components/chat/client.ts
@@ -666,13 +666,15 @@ export function addGroupMembers(chat: ChatClient, roomId: number, members: numbe
 }
 
 export async function leaveGroupRoom(chat: ChatClient, room: ChatRoom) {
-	if (room.isGroupRoom) {
-		chat.userChannel?.push('group_leave', { room_id: room.id }).receive('ok', _response => {
-			if (isInChatRoom(chat, room.id)) {
-				leaveChatRoom(chat);
-			}
-		});
+	if (!room.isGroupRoom) {
+		throw new Error(`Can't leave non-group rooms.`);
 	}
+
+	chat.userChannel?.push('group_leave', { room_id: room.id }).receive('ok', _response => {
+		if (isInChatRoom(chat, room.id)) {
+			leaveChatRoom(chat);
+		}
+	});
 }
 
 export function removeMessage(chat: ChatClient, msgId: number) {

--- a/src/app/components/chat/user-list/item/item.ts
+++ b/src/app/components/chat/user-list/item/item.ts
@@ -142,6 +142,6 @@ export default class AppChatUserListItem extends Vue {
 			return;
 		}
 
-		leaveGroupRoom(this.chat);
+		leaveGroupRoom(this.chat, this.item);
 	}
 }


### PR DESCRIPTION
Now handling the `group_leave` on user channel. This is so we can leave the group without joining the room channel we're leaving.