### PR TITLE
Adjust community audit log channel design

### DIFF
--- a/src/_common/community/activity-item/activity-item.ts
+++ b/src/_common/community/activity-item/activity-item.ts
@@ -99,7 +99,7 @@ export default class AppCommunityActivityItem extends Vue {
 				reason: this.item.action_resource.reason,
 			});
 		} else if (this.item.action_resource instanceof CommunityChannel) {
-			return '#' + this.item.action_resource.title;
+			return this.item.action_resource.title;
 		} else if (this.item.action_resource instanceof Game) {
 			return this.item.action_resource.title;
 		}

--- a/src/_common/community/activity-item/activity-item.vue
+++ b/src/_common/community/activity-item/activity-item.vue
@@ -188,7 +188,7 @@
 							newName: getExtraData('new-name'),
 						}"
 					>
-						<em>Renamed</em> a channel from #%{ oldName } to #%{ newName }.
+						<em>Renamed</em> a channel from <i>%{ oldName }</i> to <i>%{ newName }</i>.
 					</span>
 
 					<span


### PR DESCRIPTION
Remove the old "#"-prefix from channels in the audit log.