### PR TITLE
Soft fail eject post

### DIFF
--- a/src/_common/fireside/post/post-model.ts
+++ b/src/_common/fireside/post/post-model.ts
@@ -466,7 +466,9 @@ export class FiresidePost extends Model implements ContentContainerModel, Commen
 			throw new Error('Cannot reject a post to a community it is not tagged in');
 		}
 
-		return this.$_save(`/web/communities/manage/reject/${c.id}`, 'post');
+		return this.$_save(`/web/communities/manage/reject/${c.id}`, 'post', {
+			noErrorRedirect: true,
+		});
 	}
 
 	$moveChannel(community: Community, channel: CommunityChannel) {

--- a/src/app/components/event-item/controls/fireside-post/extra/extra.ts
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.ts
@@ -157,10 +157,13 @@ export default class AppEventItemControlsFiresidePostExtra extends Vue {
 
 		try {
 			await this.post.$reject(postCommunity.community);
-			this.emitReject(postCommunity.community);
 		} catch (err) {
 			console.warn('Failed to eject post');
-			return;
+		} finally {
+			// Reject the post from the community anyway when an error occurs.
+			// This most likely happens when the user ejects the post on one tab
+			// and then tries again for the same post on another tab.
+			this.emitReject(postCommunity.community);
 		}
 	}
 


### PR DESCRIPTION
When using communities with more than one client (tabs, applications, devices, etc), ejecting the same post "twice" results in the second attempt redirecting to an error page.
This PR changes that behavior so it instead fails silently and ejects the post in frontend anyway.