### PR TITLE
Track isFocused only for videos so that it ignores other posts potentially being in the view.

### DIFF
--- a/src/_common/scroll/inview/container.ts
+++ b/src/_common/scroll/inview/container.ts
@@ -92,10 +92,14 @@ export class ScrollInviewContainer {
 
 	private trackFocused() {
 		let focusedItem: ScrollInviewController | null = null;
+
+		// Loop over trying to find the new active.
 		for (const i of this.controllers) {
-			// Loop over trying to find the new active.
 			focusedItem =
-				!focusedItem || i.latestThreshold > focusedItem.latestThreshold ? i : focusedItem;
+				i.latestThreshold !== 0 &&
+				(!focusedItem || i.latestThreshold > focusedItem.latestThreshold)
+					? i
+					: focusedItem;
 
 			// Reset the active state of any ones currently marked as active.
 			// There should only ever be one.

--- a/src/app/components/activity/feed/item/item.vue
+++ b/src/app/components/activity/feed/item/item.vue
@@ -1,7 +1,12 @@
 <script lang="ts" src="./item"></script>
 
 <template>
-	<app-scroll-inview :config="InviewConfig" :controller="inviewController">
+	<component
+		:is="InviewConfigFocused ? 'app-scroll-inview' : 'div'"
+		v-bind="
+			InviewConfigFocused ? { config: InviewConfigFocused, controller: inviewController } : {}
+		"
+	>
 		<app-scroll-inview
 			:config="InviewConfigHydration"
 			@inview="onInviewHydrationChange(true)"
@@ -26,5 +31,5 @@
 				/>
 			</template>
 		</app-scroll-inview>
-	</app-scroll-inview>
+	</component>
 </template>


### PR DESCRIPTION
This should play videos more often since they don't need to be the top item in the feed anymore.