### PR TITLE
Remove unusued startup activity options from content editor

### DIFF
--- a/src/_common/comment/add/add.ts
+++ b/src/_common/comment/add/add.ts
@@ -27,9 +27,6 @@ export default class FormComment extends BaseForm<Comment> implements FormOnInit
 	@Prop(String)
 	placeholder?: string;
 
-	@Prop(String)
-	editorStartupActivity?: string;
-
 	$refs!: {
 		form: AppForm;
 	};

--- a/src/_common/comment/add/add.vue
+++ b/src/_common/comment/add/add.vue
@@ -11,7 +11,6 @@
 					max_content_length: [lengthLimit],
 				}"
 				:validate-on="['blur']"
-				:startup-activity="editorStartupActivity"
 				:max-height="maxHeight"
 				:display-rules="displayRules"
 				focus-end

--- a/src/_common/content/content-editor/content-editor.ts
+++ b/src/_common/content/content-editor/content-editor.ts
@@ -67,9 +67,6 @@ export default class AppContentEditor extends Vue implements ContentOwner {
 	@Prop(String)
 	name!: string;
 
-	@Prop(String)
-	startupActivity?: string;
-
 	/**
 	 * Used to send more information with the create temp resource request.
 	 * Passed in object is directly handed to the Api. By default `undefined`, resulting in a GET request.
@@ -108,7 +105,6 @@ export default class AppContentEditor extends Vue implements ContentOwner {
 	emojiPanelVisible = false;
 	controlsCollapsed = true;
 	isEmpty = true; // Gets updated through the update-is-empty-plugin
-	openedStartup = false; // When the gif or emoji panel opened on startup. Prevents them from opening again.
 	canShowMentionSuggestions = 0; // Indicates whether we want to currently show the mention suggestion panel. Values > 0 indicate true.
 	mentionUserCount = 0;
 
@@ -436,10 +432,6 @@ export default class AppContentEditor extends Vue implements ContentOwner {
 
 	onControlsCollapsedChanged(collapsed: boolean) {
 		this.controlsCollapsed = collapsed;
-	}
-
-	onOpenedStartup() {
-		this.openedStartup = true;
 	}
 
 	onInsertMention() {

--- a/src/_common/content/content-editor/content-editor.vue
+++ b/src/_common/content/content-editor/content-editor.vue
@@ -43,8 +43,6 @@
 							v-if="shouldShowGifButton"
 							:view="view"
 							:state-counter="stateCounter"
-							:startup-activity="openedStartup ? '' : startupActivity"
-							@opened-startup="onOpenedStartup"
 						/>
 					</transition>
 					<transition name="fade">
@@ -53,9 +51,7 @@
 							ref="emojiPanel"
 							:view="view"
 							:state-counter="stateCounter"
-							:startup-activity="openedStartup ? '' : startupActivity"
 							@visibilityChanged="onEmojiPanelVisibilityChanged"
-							@opened-startup="onOpenedStartup"
 						/>
 					</transition>
 				</app-content-editor-controls-inset-container>

--- a/src/_common/content/content-editor/controls/emoji/panel.ts
+++ b/src/_common/content/content-editor/controls/emoji/panel.ts
@@ -15,8 +15,6 @@ export default class AppContentEditorControlsEmojiPanel extends Vue {
 	view!: EditorView<ContentEditorSchema>;
 	@Prop(Number)
 	stateCounter!: number;
-	@Prop(String)
-	startupActivity?: string;
 
 	visible = false;
 	emoji = 'huh'; // gets set to a random one at mounted
@@ -65,10 +63,6 @@ export default class AppContentEditorControlsEmojiPanel extends Vue {
 
 	mounted() {
 		this.setRandomEmoji();
-		if (this.startupActivity === 'emoji') {
-			this.$emit('opened-startup');
-			this.show();
-		}
 	}
 
 	onMouseEnter() {

--- a/src/_common/content/content-editor/controls/emoji/panel.vue
+++ b/src/_common/content/content-editor/controls/emoji/panel.vue
@@ -1,32 +1,34 @@
+<script lang="ts" src="./panel"></script>
+
 <template>
 	<div class="inset-container-controls">
 		<transition name="fade">
 			<span
 				v-if="visible"
+				v-app-tooltip="panelVisible ? '' : $gettext('Insert Emoji')"
 				class="emoji-button"
 				:class="spanClass"
 				tabindex="1"
 				@click="onButtonClick"
 				@mousedown="onMouseDown"
 				@mouseenter="onMouseEnter"
-				v-app-tooltip="panelVisible ? '' : $gettext('Insert Emoji')"
 			/>
 		</transition>
 		<transition name="fade">
 			<div
 				v-if="visible && panelVisible"
-				class="emoji-panel"
 				ref="panel"
+				class="emoji-panel"
+				tabindex="1"
 				@focus="onPanelFocus"
 				@blur="onPanelBlur"
-				tabindex="1"
 			>
 				<div
 					v-for="emoji of emojis"
 					:key="emoji"
 					class="emoji-box"
-					@click="onClickEmoji(emoji)"
 					:title="':' + emoji + ':'"
+					@click="onClickEmoji(emoji)"
 				>
 					<span :class="'emoji-selector emoji emoji-' + emoji" />
 				</div>
@@ -36,5 +38,3 @@
 </template>
 
 <style lang="stylus" src="./panel.styl" scoped></style>
-
-<script lang="ts" src="./panel"></script>

--- a/src/_common/content/content-editor/controls/gif/controls.ts
+++ b/src/_common/content/content-editor/controls/gif/controls.ts
@@ -17,21 +17,11 @@ export default class AppContentEditorControlsGifControls extends Vue {
 	view!: EditorView;
 	@Prop(Number)
 	stateCounter!: number;
-	@Prop(String)
-	startupActivity?: string;
 
 	visible = false;
-	openedStartup = false;
 
 	created() {
 		this.update();
-	}
-
-	mounted() {
-		if (this.startupActivity === 'gif') {
-			this.$emit('opened-startup');
-			this.openGifModal();
-		}
 	}
 
 	@Watch('stateCounter')

--- a/src/_common/content/content-editor/controls/gif/controls.vue
+++ b/src/_common/content/content-editor/controls/gif/controls.vue
@@ -1,11 +1,13 @@
+<script lang="ts" src="./controls"></script>
+
 <template>
 	<transition name="fade">
 		<app-jolticon
 			v-if="visible"
+			v-app-tooltip="$gettext('Insert Gif')"
 			class="emoji-button inset-container-controls"
 			icon="gif"
 			@click.native.prevent="openGifModal"
-			v-app-tooltip="$gettext('Insert Gif')"
 		/>
 	</transition>
 </template>
@@ -25,5 +27,3 @@
 	&:focus
 		outline: none
 </style>
-
-<script lang="ts" src="./controls"></script>

--- a/src/_common/form-vue/control/content/content.ts
+++ b/src/_common/form-vue/control/content/content.ts
@@ -30,9 +30,6 @@ export default class AppFormControlContent extends BaseFormControlTS {
 	@Prop(Number)
 	minHeight!: number;
 
-	@Prop(String)
-	startupActivity?: string;
-
 	@Prop(Object) tempResourceContextData?: Object;
 
 	@Prop(propOptional(Boolean, false)) compact!: boolean;

--- a/src/_common/form-vue/control/content/content.vue
+++ b/src/_common/form-vue/control/content/content.vue
@@ -17,7 +17,6 @@
 			:model-id="modelId"
 			:value="controlVal"
 			:min-height="minHeight"
-			:startup-activity="startupActivity"
 			:temp-resource-context-data="tempResourceContextData"
 			:single-line-mode="singleLineMode"
 			:max-height="maxHeight"


### PR DESCRIPTION
Due to the removal of inline comments with https://github.com/gamejolt/gamejolt/pull/675, this PR removes the leftover "startup activity" functionality from Content Editor, which is now unused.