### PR TITLE
Fix media slider swiping not updating end-item positions

### DIFF
--- a/src/app/components/activity/feed/devlog-post/media/media.ts
+++ b/src/app/components/activity/feed/devlog-post/media/media.ts
@@ -73,6 +73,7 @@ export default class AppActivityFeedDevlogPostMedia extends Vue implements Light
 
 	goNext() {
 		if (this.page >= this.post.media.length) {
+			this._updateSliderOffset();
 			return;
 		}
 
@@ -84,6 +85,7 @@ export default class AppActivityFeedDevlogPostMedia extends Vue implements Light
 
 	goPrev() {
 		if (this.page <= 1) {
+			this._updateSliderOffset();
 			return;
 		}
 


### PR DESCRIPTION
Fixes a visual bug where swiping to an item that doesn't exist wouldn't update the slider position back to the previous item.