### PR TITLE
Don't load the responsive image URL until we have mounted to pull the…

### DIFF
--- a/src/_common/img/responsive/responsive.ts
+++ b/src/_common/img/responsive/responsive.ts
@@ -17,7 +17,9 @@ export class AppImgResponsive extends Vue {
 	private resize$: EventSubscription | undefined;
 
 	created() {
-		this.processedSrc = this.src;
+		if (GJ_IS_SSR) {
+			this.processedSrc = this.src;
+		}
 	}
 
 	async mounted() {


### PR DESCRIPTION
… correct width.

This should solve cases where it was trying to load an image and then immediately canceling the call when loading the new image.

It's also just less data to load since it should only pull when it can calculate the correct image.