### PR TITLE
Change content-viewer dimension-capping usage

### DIFF
--- a/src/_common/content/components/gif/gif.vue
+++ b/src/_common/content/components/gif/gif.vue
@@ -7,14 +7,12 @@
 		@removed="onRemoved"
 	>
 		<div class="-outer content-gif">
-			<div
+			<app-responsive-dimensions
 				ref="container"
-				v-app-observe-dimensions="computeSize"
 				class="-container"
-				:style="{
-					width: containerWidth,
-					height: containerHeight,
-				}"
+				:ratio="width / height"
+				:max-width="maxWidth"
+				:max-height="maxHeight"
 			>
 				<app-scroll-inview
 					:config="InviewConfig"
@@ -29,7 +27,7 @@
 						:should-play="shouldPlay"
 					/>
 				</app-scroll-inview>
-			</div>
+			</app-responsive-dimensions>
 		</div>
 	</app-base-content-component>
 </template>

--- a/src/_common/content/components/media-item/media-item.vue
+++ b/src/_common/content/components/media-item/media-item.vue
@@ -18,15 +18,13 @@
 				'align-items': itemAlignment,
 			}"
 		>
-			<div
+			<app-responsive-dimensions
 				ref="container"
-				v-app-observe-dimensions="computeSize"
 				class="media-item-container"
 				:class="{ '-zoomable': canFullscreenItem }"
-				:style="{
-					width: containerWidth,
-					height: containerHeight,
-				}"
+				:ratio="mediaItem ? mediaItem.width / mediaItem.height : null"
+				:max-height="maxHeight"
+				:max-width="maxWidth"
 			>
 				<app-media-item-backdrop
 					:class="{ '-backdrop': shouldShowPlaceholder }"
@@ -35,7 +33,7 @@
 				>
 					<template v-if="mediaItem">
 						<component
-							:is="hasLink && !isEditing ? 'a' : 'span'"
+							:is="hasLink && !isEditing ? 'a' : 'div'"
 							:href="hasLink && !isEditing ? href : undefined"
 							rel="nofollow noopener"
 							target="_blank"
@@ -76,7 +74,7 @@
 						</app-link-external>
 					</small>
 				</div>
-			</div>
+			</app-responsive-dimensions>
 			<span v-if="mediaItem && hasCaption" class="text-muted">
 				<em>{{ caption }}</em>
 			</span>

--- a/src/_common/content/components/media-item/media-item.vue
+++ b/src/_common/content/components/media-item/media-item.vue
@@ -34,6 +34,7 @@
 					<template v-if="mediaItem">
 						<component
 							:is="hasLink && !isEditing ? 'a' : 'div'"
+							class="-img-container"
 							:href="hasLink && !isEditing ? href : undefined"
 							rel="nofollow noopener"
 							target="_blank"
@@ -108,6 +109,10 @@
 // While the image is still loading, we show a dimmed background as a fallback for app-media-item-backdrop
 .-backdrop
 	change-bg('bg-offset')
+
+// Stretch out the img container so that img-responsive is able to fetch the proper quality item.
+.-img-container
+	width: 100%
 
 .media-item
 	width: 100%

--- a/src/_common/img/responsive/responsive.ts
+++ b/src/_common/img/responsive/responsive.ts
@@ -1,6 +1,7 @@
 import Vue, { CreateElement } from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { EventSubscription } from '../../../system/event/event-topic';
+import { sleep } from '../../../utils/utils';
 import { Ruler } from '../../ruler/ruler-service';
 import { Screen } from '../../screen/screen-service';
 import { ImgHelper } from '../helper/helper-service';
@@ -17,7 +18,9 @@ export class AppImgResponsive extends Vue {
 	private resize$: EventSubscription | undefined;
 
 	created() {
-		this.processedSrc = this.src;
+		if (GJ_IS_SSR) {
+			this.processedSrc = this.src;
+		}
 	}
 
 	async mounted() {
@@ -50,6 +53,9 @@ export class AppImgResponsive extends Vue {
 	}
 
 	private async updateSrc() {
+		// Try waiting for any resizes and breakpoint changes to happen before getting the container information.
+		await sleep(0);
+
 		const containerWidth = Ruler.width(this.$el.parentNode as HTMLElement);
 		const containerHeight = Ruler.height(this.$el.parentNode as HTMLElement);
 


### PR DESCRIPTION
Use `AppResponsiveDimensions` in content-viewer components that were using similar logic.

includes: https://github.com/gamejolt/gamejolt/pull/692

Should fix any issues with getting the wrong item from img-responsive, particularly when moving between breakpoints.