### PR TITLE
Fix community selector

### DIFF
--- a/src/app/components/forms/post/post.ts
+++ b/src/app/components/forms/post/post.ts
@@ -304,7 +304,11 @@ export default class FormPost extends BaseForm<FormPostModel>
 	}
 
 	get shouldShowCommunities() {
-		return this.attachedCommunities.length > 0 || this.possibleCommunities.length > 0;
+		return (
+			this.attachedCommunities.length > 0 ||
+			this.possibleCommunities.length > 0 ||
+			this.incompleteDefaultCommunity
+		);
 	}
 
 	get incompleteDefaultCommunity() {


### PR DESCRIPTION
Fixes the community selector bar not showing up when the user:

 - only joined a single community
 - and they are in viewing that single community
 - and they are trying to post from the Featured/All Posts channels
