### PR TITLE
Auth modal no backdrop close

### DIFF
--- a/src/_common/auth/auth-modal.service.ts
+++ b/src/_common/auth/auth-modal.service.ts
@@ -11,6 +11,7 @@ export class AuthModal {
 				),
 			size: 'sm',
 			props: {},
+			noBackdropClose: true,
 		});
 	}
 }

--- a/src/_common/auth/auth-modal.vue
+++ b/src/_common/auth/auth-modal.vue
@@ -1,3 +1,5 @@
+<script lang="ts" src="./auth-modal"></script>
+
 <template>
 	<app-modal>
 		<div class="modal-controls">
@@ -13,8 +15,6 @@
 		</div>
 	</app-modal>
 </template>
-
-<script lang="ts" src="./auth-modal"></script>
 
 <style lang="stylus" scoped>
 .-auth-container


### PR DESCRIPTION
Don't allow guests to close the auth modal on backdrop.
This is because stuff like password managers might force them to click outside the modal, in an overlay, which doesn't capture the event.