### PR TITLE
Add message when moving posts in community with just 1 channel

### DIFF
--- a/src/app/components/community/move-post/modal/modal.ts
+++ b/src/app/components/community/move-post/modal/modal.ts
@@ -16,6 +16,11 @@ export default class AppCommunityMovePostModal extends BaseModal {
 	@Prop(Array)
 	channels!: CommunityChannel[];
 
+	get canMove() {
+		// More than 1, since the post can't be moved to the channel it's already in.
+		return this.channels.length > 1;
+	}
+
 	onChannelSelected(channel: CommunityChannel) {
 		this.modal.resolve(channel);
 	}

--- a/src/app/components/community/move-post/modal/modal.vue
+++ b/src/app/components/community/move-post/modal/modal.vue
@@ -1,3 +1,5 @@
+<script lang="ts" src="./modal"></script>
+
 <template>
 	<app-modal>
 		<div class="modal-controls">
@@ -14,12 +16,16 @@
 
 		<div class="modal-body">
 			<app-community-move-post
+				v-if="canMove"
 				:fireside-post-community="firesidePostCommunity"
 				:channels="channels"
 				@select="onChannelSelected"
 			/>
+			<span v-else>
+				<translate>
+					There are no channels in this community that the post can be moved to.
+				</translate>
+			</span>
 		</div>
 	</app-modal>
 </template>
-
-<script lang="ts" src="./modal"></script>


### PR DESCRIPTION
Before, the modal would just have an empty body with a disabled "MOVE" button. Now it shows a message instead.