### PR TITLE
Block from post menu

### DIFF
--- a/src/_common/form-vue/control/control.ts
+++ b/src/_common/form-vue/control/control.ts
@@ -1,5 +1,6 @@
 import { createTextMaskInputElement } from 'text-mask-core/dist/textMaskCore';
 import { Component, Prop } from 'vue-property-decorator';
+import { propOptional } from '../../../utils/vue';
 import BaseFormControl from './base';
 
 @Component({})
@@ -10,6 +11,7 @@ export default class AppFormControl extends BaseFormControl {
 	@Prop(Array) validateOn!: string[];
 	@Prop(Number) validateDelay!: number;
 	@Prop(Array) mask!: (string | RegExp)[];
+	@Prop(propOptional(Boolean, false)) disabled!: boolean;
 
 	controlVal = '';
 	maskedInputElem: any = null;

--- a/src/_common/form-vue/control/control.vue
+++ b/src/_common/form-vue/control/control.vue
@@ -1,15 +1,16 @@
+<script lang="ts" src="./control"></script>
+
 <template>
 	<input
 		:id="id"
+		v-validate="{ rules: validationRules }"
+		:data-vv-validate-on="validateOn"
+		:data-vv-delay="validateDelay"
 		:name="group.name"
 		class="form-control"
 		:type="controlType"
 		:value="controlVal"
+		:disabled="disabled"
 		@input="onChange"
-		v-validate="{ rules: validationRules }"
-		:data-vv-validate-on="validateOn"
-		:data-vv-delay="validateDelay"
 	/>
 </template>
-
-<script lang="ts" src="./control"></script>

--- a/src/app/components/community/block-user-modal/block-user-modal.service.ts
+++ b/src/app/components/community/block-user-modal/block-user-modal.service.ts
@@ -1,0 +1,20 @@
+import { asyncComponentLoader } from '../../../../utils/utils';
+import { Community } from '../../../../_common/community/community.model';
+import { Modal } from '../../../../_common/modal/modal.service';
+import { User } from '../../../../_common/user/user.model';
+
+export class CommunityBlockUserModal {
+	static async show(user: User, community: Community) {
+		return await Modal.show<boolean>({
+			modalId: 'CommunityBlockUser',
+			component: () =>
+				asyncComponentLoader(
+					import(
+						/* webpackChunkName: "CommunityBlockUserModal" */ './block-user-modal.vue'
+					)
+				),
+			props: { user, community },
+			size: 'lg',
+		});
+	}
+}

--- a/src/app/components/community/block-user-modal/block-user-modal.ts
+++ b/src/app/components/community/block-user-modal/block-user-modal.ts
@@ -1,0 +1,20 @@
+import { Component, Prop } from 'vue-property-decorator';
+import { propRequired } from '../../../../utils/vue';
+import { Community } from '../../../../_common/community/community.model';
+import { BaseModal } from '../../../../_common/modal/base';
+import { User } from '../../../../_common/user/user.model';
+import FormCommunityBlock from '../../forms/community/ban/block.vue';
+
+@Component({
+	components: {
+		FormCommunityBlock,
+	},
+})
+export default class AppCommunityBlocKUserModal extends BaseModal {
+	@Prop(propRequired(Community)) community!: Community;
+	@Prop(propRequired(User)) user!: User;
+
+	onFormSubmit() {
+		this.modal.resolve(true);
+	}
+}

--- a/src/app/components/community/block-user-modal/block-user-modal.vue
+++ b/src/app/components/community/block-user-modal/block-user-modal.vue
@@ -1,0 +1,21 @@
+<script lang="ts" src="./block-user-modal"></script>
+
+<template>
+	<app-modal>
+		<div class="modal-controls">
+			<app-button @click="modal.dismiss()">
+				<translate>Close</translate>
+			</app-button>
+		</div>
+		<div class="modal-header">
+			<h2 class="modal-title">
+				<translate>Block User</translate>
+			</h2>
+		</div>
+		<div class="modal-body">
+			<form-community-block :community="community" :user="user" @submit="onFormSubmit" />
+		</div>
+	</app-modal>
+</template>
+
+<style lang="stylus" scoped></style>

--- a/src/app/components/event-item/controls/fireside-post/extra/extra.ts
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.ts
@@ -20,6 +20,7 @@ import { ReportModal } from '../../../../../../_common/report/modal/modal.servic
 import { AppState, AppStore } from '../../../../../../_common/store/app-store';
 import { User } from '../../../../../../_common/user/user.model';
 import { Store } from '../../../../../store/index';
+import { CommunityBlockUserModal } from '../../../../community/block-user-modal/block-user-modal.service';
 import { CommunityMovePostModal } from '../../../../community/move-post/modal/modal.service';
 import { AppCommunityPerms } from '../../../../community/perms/perms';
 
@@ -167,6 +168,10 @@ export default class AppEventItemControlsFiresidePostExtra extends Vue {
 			console.warn('Failed to eject post');
 			return;
 		}
+	}
+
+	blockFromCommunity(postCommunity: FiresidePostCommunity) {
+		CommunityBlockUserModal.show(this.post.user, postCommunity.community);
 	}
 
 	copyShareUrl() {

--- a/src/app/components/event-item/controls/fireside-post/extra/extra.ts
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.ts
@@ -92,6 +92,11 @@ export default class AppEventItemControlsFiresidePostExtra extends Vue {
 		return false;
 	}
 
+	get shouldShowBlockCommunityUser() {
+		// Cannot block yourself.
+		return this.post.user.id !== this.user?.id;
+	}
+
 	getProviderIcon(provider: string) {
 		return getLinkedAccountPlatformIcon(provider);
 	}

--- a/src/app/components/event-item/controls/fireside-post/extra/extra.vue
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.vue
@@ -112,6 +112,13 @@
 								</translate>
 							</a>
 						</app-community-perms>
+
+						<app-community-perms :community="i.community" required="community-blocks">
+							<a class="list-group-item has-icon" @click.stop="blockFromCommunity(i)">
+								<app-jolticon icon="friend-remove-2" />
+								<translate>Block author</translate>
+							</a>
+						</app-community-perms>
 					</div>
 				</template>
 			</div>

--- a/src/app/components/event-item/controls/fireside-post/extra/extra.vue
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.vue
@@ -113,7 +113,11 @@
 							</a>
 						</app-community-perms>
 
-						<app-community-perms :community="i.community" required="community-blocks">
+						<app-community-perms
+							v-if="shouldShowBlockCommunityUser"
+							:community="i.community"
+							required="community-blocks"
+						>
 							<a class="list-group-item has-icon" @click.stop="blockFromCommunity(i)">
 								<app-jolticon icon="friend-remove-2" />
 								<translate>Block author</translate>

--- a/src/app/components/event-item/controls/fireside-post/extra/extra.vue
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.vue
@@ -105,7 +105,7 @@
 								class="list-group-item has-icon"
 								@click.stop="rejectFromCommunity(i)"
 							>
-								<app-jolticon icon="remove" />
+								<app-jolticon icon="logout" class="-eject" />
 
 								<translate :translate-params="{ community: i.community.name }">
 									Eject from %{ community }
@@ -120,7 +120,9 @@
 						>
 							<a class="list-group-item has-icon" @click.stop="blockFromCommunity(i)">
 								<app-jolticon icon="friend-remove-2" />
-								<translate>Block author</translate>
+								<translate :translate-params="{ community: i.community.name }">
+									Block author from %{ community }
+								</translate>
 							</a>
 						</app-community-perms>
 					</div>
@@ -152,4 +154,7 @@
 		left: -($list-group-icon-width - 1px)
 		top: -2px
 		margin-right: -($list-group-icon-width - 5px)
+
+.-eject
+	transform: rotateZ(90deg)
 </style>

--- a/src/app/components/forms/community/ban/block.ts
+++ b/src/app/components/forms/community/ban/block.ts
@@ -1,10 +1,12 @@
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
+import { propOptional, propRequired } from '../../../../../utils/vue';
 import { Api } from '../../../../../_common/api/api.service';
 import { Community } from '../../../../../_common/community/community.model';
 import AppFormControlToggle from '../../../../../_common/form-vue/control/toggle/toggle.vue';
 import { BaseForm, FormOnInit, FormOnSubmit } from '../../../../../_common/form-vue/form.service';
 import { Growls } from '../../../../../_common/growls/growls.service';
+import { User } from '../../../../../_common/user/user.model';
 
 interface FormModel {
 	username: string;
@@ -21,10 +23,11 @@ interface FormModel {
 })
 export default class FormCommunityBlock extends BaseForm<FormModel>
 	implements FormOnInit, FormOnSubmit {
-	@Prop(Community)
-	community!: Community;
+	@Prop(propRequired(Community)) community!: Community;
+	@Prop(propOptional(User, null)) user?: User | null;
 
 	resetOnSubmit = true;
+	usernameLocked = false;
 
 	get defaultReasons() {
 		return {
@@ -51,9 +54,14 @@ export default class FormCommunityBlock extends BaseForm<FormModel>
 	}
 
 	onInit() {
-		this.setField('reasonType', this.defaultReasons.spam);
+		this.setField('reasonType', 'spam');
 		this.setField('expiry', 'week');
 		this.setField('ejectPosts', true);
+
+		if (this.user) {
+			this.setField('username', this.user.username);
+			this.usernameLocked = true;
+		}
 	}
 
 	async onSubmit() {

--- a/src/app/components/forms/community/ban/block.vue
+++ b/src/app/components/forms/community/ban/block.vue
@@ -1,6 +1,8 @@
+<script lang="ts" src="./block"></script>
+
 <template>
 	<app-form name="communityBlockForm">
-		<app-form-group name="username">
+		<app-form-group v-if="!usernameLocked" name="username">
 			<app-form-control
 				type="text"
 				:rules="{
@@ -20,6 +22,12 @@
 				/>
 			</app-form-control-errors>
 		</app-form-group>
+		<template v-else>
+			<label class="control-label"><translate>Username</translate></label>
+			<div class="form-control -locked-username">
+				{{ formModel.username }}
+			</div>
+		</template>
 
 		<app-form-group name="reasonType" :label="$gettext('Block reason')">
 			<div class="radio" v-for="(reasonDisplay, reason) in defaultReasons" :key="reason">
@@ -57,20 +65,30 @@
 			<app-form-control-errors />
 		</app-form-group>
 
-		<app-form-group name="ejectPosts" :label="$gettext(`Eject user's posts from the community?`)">
+		<app-form-group
+			name="ejectPosts"
+			:label="$gettext(`Eject user's posts from the community?`)"
+		>
 			<app-form-control-toggle class="pull-right" />
 			<p class="help-block">
 				<translate>
-					Once the user is blocked, all their posts will be ejected from the community. This also
-					affects their featured posts.
+					Once the user is blocked, all their posts will be ejected from the community.
+					This also affects their featured posts.
 				</translate>
 			</p>
 		</app-form-group>
 
-		<app-form-button>
+		<app-form-button :disabled="!valid">
 			<translate>Block</translate>
 		</app-form-button>
 	</app-form>
 </template>
 
-<script lang="ts" src="./block"></script>
+<style lang="stylus" scoped>
+@import '~styles/variables'
+@import '~styles-lib/mixins'
+
+.-locked-username
+	margin-bottom: ($line-height-computed * 1.5)
+	cursor: not-allowed
+</style>

--- a/src/app/components/forms/community/ban/block.vue
+++ b/src/app/components/forms/community/ban/block.vue
@@ -2,7 +2,7 @@
 
 <template>
 	<app-form name="communityBlockForm">
-		<app-form-group v-if="!usernameLocked" name="username">
+		<app-form-group name="username">
 			<app-form-control
 				type="text"
 				:rules="{
@@ -13,6 +13,7 @@
 					},
 				}"
 				:validate-on="['blur']"
+				:disabled="usernameLocked"
 			/>
 
 			<app-form-control-errors :label="$gettext('username')">
@@ -22,15 +23,9 @@
 				/>
 			</app-form-control-errors>
 		</app-form-group>
-		<template v-else>
-			<label class="control-label"><translate>Username</translate></label>
-			<div class="form-control -locked-username">
-				{{ formModel.username }}
-			</div>
-		</template>
 
 		<app-form-group name="reasonType" :label="$gettext('Block reason')">
-			<div class="radio" v-for="(reasonDisplay, reason) in defaultReasons" :key="reason">
+			<div v-for="(reasonDisplay, reason) in defaultReasons" :key="reason" class="radio">
 				<label>
 					<app-form-control-radio :value="reason" />
 					{{ reasonDisplay }}
@@ -56,7 +51,7 @@
 		</app-form-group>
 
 		<app-form-group name="expiry" :label="$gettext('Block expires in...')">
-			<div class="radio" v-for="(expiryDisplay, expiry) in expiryOptions" :key="expiry">
+			<div v-for="(expiryDisplay, expiry) in expiryOptions" :key="expiry" class="radio">
 				<label>
 					<app-form-control-radio :value="expiry" />
 					{{ expiryDisplay }}
@@ -83,12 +78,3 @@
 		</app-form-button>
 	</app-form>
 </template>
-
-<style lang="stylus" scoped>
-@import '~styles/variables'
-@import '~styles-lib/mixins'
-
-.-locked-username
-	margin-bottom: ($line-height-computed * 1.5)
-	cursor: not-allowed
-</style>


### PR DESCRIPTION
Adds a new entry to the post extra menu to directly block a user from a community.
Clicking that entry opens a new modal with the familiar block form, and the author of the selected post preset (and locked).

Blocking a user from there does not eject the post in the feed the menu was opened with.

You are not allowed to block yourself.

The menu entry does appear for posts made by collaborators, but when trying to submit the form a growl will appear that informs the user that a collaborator cannot be blocked from the community, and that the user has to manually remove them from the Moderators list first.

A user's block can also be overwritten by a new one by blocking them again, and the menu entry will appear for posts of users that are already blocked from the community.