### PR TITLE
Content image remove bmp

### DIFF
--- a/src/_common/content/content-editor/controls/block/controls.ts
+++ b/src/_common/content/content-editor/controls/block/controls.ts
@@ -128,7 +128,7 @@ export default class AppContentEditorBlockControls extends Vue {
 	onClickMedia() {
 		const input = document.createElement('input');
 		input.type = 'file';
-		input.accept = '.png,.jpg,.jpeg,.gif,.bmp,.webp';
+		input.accept = '.png,.jpg,.jpeg,.gif,.webp';
 		input.multiple = true;
 
 		input.onchange = e => {


### PR DESCRIPTION
We accidentally allowed bmp as a valid upload mime type for content editor images, this removes that type.