### PR TITLE
Content Viewer white-space

### DIFF
--- a/src/_common/content/content-viewer/content-viewer.vue
+++ b/src/_common/content/content-viewer/content-viewer.vue
@@ -17,5 +17,6 @@
 // Because white space is rendered out in the editor, we want the viewer to get as close to that
 // as possible. HTML by default collapses white space, and this overrides that behavior.
 >>> p > span
+	white-space: pre-wrap
 	white-space: break-spaces
 </style>

--- a/src/_common/content/content-viewer/content-viewer.vue
+++ b/src/_common/content/content-viewer/content-viewer.vue
@@ -13,4 +13,9 @@
 <style lang="stylus" scoped>
 >>> p > code
 	white-space: normal
+
+// Because white space is rendered out in the editor, we want the viewer to get as close to that
+// as possible. HTML by default collapses white space, and this overrides that behavior.
+>>> p > span
+	white-space: break-spaces
 </style>


### PR DESCRIPTION
Uses `white-space: break-spaces` (https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) to render white space in Content Viewer p > span elements to match how white space is rendered in the editor.

Basically, do not collapse white space ever, and break using white space to fit the parent container restraints.