### PR TITLE
Fix delete message timesplit

### DIFF
--- a/src/app/components/chat/client.ts
+++ b/src/app/components/chat/client.ts
@@ -440,7 +440,7 @@ export function queueChatMessage(chat: ChatClient, content: string, roomId: numb
 	sendChatMessage(chat, message);
 }
 
-function setTimeSplit(chat: ChatClient, roomId: number, message: ChatMessage) {
+export function setTimeSplit(chat: ChatClient, roomId: number, message: ChatMessage) {
 	message.combine = false;
 	message.dateSplit = false;
 


### PR DESCRIPTION
Recalcs the time split on surrounding messages of a deleted message to make sure correct splits between time/users are shown.