### PR TITLE
Use page volume for feed video player

### DIFF
--- a/src/_common/video/player/controller.ts
+++ b/src/_common/video/player/controller.ts
@@ -61,7 +61,8 @@ export class VideoPlayerController {
 			case 'feed':
 				this.volume = SettingVideoPlayerFeedMuted.get()
 					? 0
-					: SettingVideoPlayerFeedVolume.get();
+					: // Use the page player volume because the feed player has no volume control.
+					  SettingVideoPlayerVolume.get();
 				this.queuedPlaybackChange = SettingVideoPlayerFeedAutoplay.get()
 					? 'playing'
 					: 'paused';

--- a/src/_common/video/video.ts
+++ b/src/_common/video/video.ts
@@ -198,7 +198,7 @@ export default class AppVideo extends Vue {
 		}
 	}
 
-	@Watch('player.volume')
+	@Watch('player.volume', { immediate: true })
 	syncVolume() {
 		if (!this.video) {
 			return;

--- a/src/app/components/activity/feed/_video-player/video-player.ts
+++ b/src/app/components/activity/feed/_video-player/video-player.ts
@@ -13,7 +13,10 @@ import {
 import { Screen } from '../../../../../_common/screen/screen-service';
 import { ScrollInviewController } from '../../../../../_common/scroll/inview/controller';
 import { AppScrollInview } from '../../../../../_common/scroll/inview/inview';
-import { SettingVideoPlayerFeedAutoplay } from '../../../../../_common/settings/settings.service';
+import {
+	SettingVideoPlayerFeedAutoplay,
+	SettingVideoPlayerVolume,
+} from '../../../../../_common/settings/settings.service';
 import {
 	scrubVideoVolume,
 	toggleVideoPlayback,
@@ -174,7 +177,11 @@ export default class AppActivityFeedVideoPlayer extends Vue {
 			return;
 		}
 
-		scrubVideoVolume(this.player, this.player.volume ? 0 : 1, 'end');
+		scrubVideoVolume(
+			this.player,
+			this.player.volume ? 0 : SettingVideoPlayerVolume.get(),
+			'end'
+		);
 		trackVideoPlayerEvent(
 			this.player,
 			!this.player.volume ? 'mute' : 'unmute',


### PR DESCRIPTION
Because the feed video player has no volume control, it always plays videos at 100% volume.
With this PR the feed video volume is set from the same value as the post page video volume.