### PR TITLE
Content Editor: Implement robust link mark parsing

### DIFF
--- a/src/_common/content/content-editor/schemas/content-editor-schema.ts
+++ b/src/_common/content/content-editor/schemas/content-editor-schema.ts
@@ -2,7 +2,7 @@ import { Schema } from 'prosemirror-model';
 import { schema as basicSchema } from 'prosemirror-schema-basic';
 import { ContextCapabilities } from '../../content-context';
 import { ContentObjectType } from '../../content-object';
-import { link } from './specs/marks/link-markspec';
+import { customLink, link } from './specs/marks/link-markspec';
 import { mention } from './specs/marks/mention-markspec';
 import { strike } from './specs/marks/strike-markspec';
 import { tag } from './specs/marks/tag-markspec';
@@ -123,7 +123,11 @@ function generateMarks(capabilities: ContextCapabilities) {
 		marks.code = basicSchema.marks.code.spec;
 	}
 	if (capabilities.textLink) {
-		marks.link = link;
+		if (capabilities.customLink) {
+			marks.link = customLink;
+		} else {
+			marks.link = link;
+		}
 	}
 	if (capabilities.textStrike) {
 		marks.strike = strike;

--- a/src/_common/content/content-editor/schemas/specs/marks/link-markspec.ts
+++ b/src/_common/content/content-editor/schemas/specs/marks/link-markspec.ts
@@ -1,36 +1,104 @@
-import { Mark, MarkSpec } from 'prosemirror-model';
+import { DOMOutputSpec, Fragment, Mark, MarkSpec } from 'prosemirror-model';
+import { ContentEditorSchema } from '../../content-editor-schema';
 
 export const LINK_LENGTH = 23;
 
+const linkAttrs = {
+	href: {},
+	title: { default: null },
+	autolink: { default: false },
+};
+
+const getAttrsContentEditorLink = function(domNode: Element) {
+	return {
+		href: domNode.getAttribute('data-href'),
+		title: domNode.getAttribute('data-title'),
+		autolink: domNode.getAttribute('data-autolink'),
+	};
+};
+
+const toDOM = function(mark: Mark, _inline: boolean): DOMOutputSpec {
+	let { href, title, autolink } = mark.attrs;
+	return [
+		'span',
+		{
+			class: 'content-editor-link',
+			title: href,
+			'data-href': href,
+			'data-title': title,
+			'data-autolink': autolink,
+		},
+		0,
+	];
+};
+
+/**
+ * The basic link element. Used for autolinks. Does not support parsing custom links.
+ */
 export const link = {
-	attrs: {
-		href: {},
-		title: { default: null },
-		autolink: { default: false },
-	},
+	attrs: linkAttrs,
 	inclusive: false,
-	toDOM(mark: Mark, _inline: boolean) {
-		let { href, title, autolink } = mark.attrs;
-		return [
-			'span',
-			{
-				class: 'content-editor-link',
-				title: href,
-				'data-href': href,
-				'data-title': title,
-				'data-autolink': autolink,
-			},
-			0,
-		];
-	},
+	toDOM,
 	parseDOM: [
+		// Parse pasted content editor link text.
 		{
 			tag: 'span[data-href]',
+			getAttrs: getAttrsContentEditorLink,
+		},
+		// Parse pasted HTML anchor tag.
+		{
+			tag: 'a',
 			getAttrs(domNode: Element) {
+				const href = domNode.getAttribute('href') ?? '';
+				const title = href;
+				const isAutolink = false;
+
 				return {
-					href: domNode.getAttribute('data-href'),
-					title: domNode.getAttribute('data-title'),
-					autolink: domNode.getAttribute('data-autolink'),
+					href,
+					title,
+					autolink: isAutolink,
+				};
+			},
+			// Make sure the content of the node is the href, since this is an autolink.
+			// Replaces whatever was between the <a>...</a> tags.
+			getContent(node: Node, schema: ContentEditorSchema) {
+				const el = node as Element;
+				const href = el.getAttribute('href');
+				if (href) {
+					return Fragment.from(schema.text(href));
+				}
+
+				return Fragment.empty;
+			},
+		},
+	],
+} as MarkSpec;
+
+/**
+ * Custom link mark spec, that also supports parsing and inserting any custom link.
+ */
+export const customLink = {
+	attrs: linkAttrs,
+	inclusive: false,
+	toDOM,
+	parseDOM: [
+		// Parse pasted content editor link text.
+		{
+			tag: 'span[data-href]',
+			getAttrs: getAttrsContentEditorLink,
+		},
+		// Parse pasted HTML anchor tag.
+		{
+			tag: 'a',
+			getAttrs(domNode: Element) {
+				const href = domNode.getAttribute('href') ?? '';
+				const title = (domNode.textContent || domNode.getAttribute('title') || href).trim();
+				const isAutolink = title === href;
+
+				return {
+					href,
+					title,
+					autolink: isAutolink,
 				};
 			},
 		},


### PR DESCRIPTION
Implements more robust link parsing when pasting links into Content Editor fields.

Two separate mark specs are now provided, depending on whether custom links are allowed or not.
The mark specs handle:
 - Pasting links from Content Editor sources
 - Pasting links from websites (HTML anchor tags)
 - Automatically setting href/title depending on custom link settings

This PR solves both the issue of copy-pasting links from other websites not appearing as links, and pasting links copied from the MS Edge URL bar.