### PR TITLE
Eject blocked user's post if selected

### DIFF
--- a/src/app/components/community/block-user-modal/block-user-modal.service.ts
+++ b/src/app/components/community/block-user-modal/block-user-modal.service.ts
@@ -3,9 +3,13 @@ import { Community } from '../../../../_common/community/community.model';
 import { Modal } from '../../../../_common/modal/modal.service';
 import { User } from '../../../../_common/user/user.model';
 
+type ResultType = {
+	ejectPosts: boolean;
+};
+
 export class CommunityBlockUserModal {
 	static async show(user: User, community: Community) {
-		return await Modal.show<boolean>({
+		return await Modal.show<ResultType>({
 			modalId: 'CommunityBlockUser',
 			component: () =>
 				asyncComponentLoader(

--- a/src/app/components/community/block-user-modal/block-user-modal.ts
+++ b/src/app/components/community/block-user-modal/block-user-modal.ts
@@ -3,6 +3,7 @@ import { propRequired } from '../../../../utils/vue';
 import { Community } from '../../../../_common/community/community.model';
 import { BaseModal } from '../../../../_common/modal/base';
 import { User } from '../../../../_common/user/user.model';
+import { FormModel } from '../../../components/forms/community/ban/block';
 import FormCommunityBlock from '../../forms/community/ban/block.vue';
 
 @Component({
@@ -14,7 +15,7 @@ export default class AppCommunityBlocKUserModal extends BaseModal {
 	@Prop(propRequired(Community)) community!: Community;
 	@Prop(propRequired(User)) user!: User;
 
-	onFormSubmit() {
-		this.modal.resolve(true);
+	onFormSubmit(model: FormModel) {
+		this.modal.resolve({ ejectPosts: model.ejectPosts });
 	}
 }

--- a/src/app/components/event-item/controls/fireside-post/extra/extra.ts
+++ b/src/app/components/event-item/controls/fireside-post/extra/extra.ts
@@ -173,8 +173,18 @@ export default class AppEventItemControlsFiresidePostExtra extends Vue {
 		}
 	}
 
-	blockFromCommunity(postCommunity: FiresidePostCommunity) {
-		CommunityBlockUserModal.show(this.post.user, postCommunity.community);
+	async blockFromCommunity(postCommunity: FiresidePostCommunity) {
+		const result = await CommunityBlockUserModal.show(this.post.user, postCommunity.community);
+
+		// Pretend to eject the post from the feed.
+		// Because the option "eject post" was selected in the form, all posts by the blocked
+		// author will be ejected automatically in the backend.
+		if (result && result.ejectPosts) {
+			// Remove community from post.
+			arrayRemove(this.post.communities, i => i.id === postCommunity.id);
+			// Eject from feed.
+			this.emitReject(postCommunity.community);
+		}
 	}
 
 	copyShareUrl() {

--- a/src/app/components/forms/community/ban/block.ts
+++ b/src/app/components/forms/community/ban/block.ts
@@ -8,7 +8,7 @@ import { BaseForm, FormOnInit, FormOnSubmit } from '../../../../../_common/form-
 import { Growls } from '../../../../../_common/growls/growls.service';
 import { User } from '../../../../../_common/user/user.model';
 
-interface FormModel {
+export interface FormModel {
 	username: string;
 	reasonType: string;
 	reason: string;


### PR DESCRIPTION
When blocking a user from the post menu and ejecting their posts, it's helpful to visually remove the post from the feed (and the community from the post).