### PR TITLE
Fix chat autoscroll behavior

### DIFF
--- a/src/app/components/chat/window/output/output.vue
+++ b/src/app/components/chat/window/output/output.vue
@@ -16,18 +16,20 @@
 
 			<app-loading v-if="isLoadingOlder" class="loading-centered" />
 
-			<div v-for="message of allMessages" :key="message.id">
-				<div v-if="message.dateSplit" class="-date-split">
-					<span class="-inner">{{ message.logged_on | date('mediumDate') }}</span>
+			<div v-app-observe-dimensions="tryAutoscroll">
+				<div v-for="message of allMessages" :key="message.id">
+					<div v-if="message.dateSplit" class="-date-split">
+						<span class="-inner">{{ message.logged_on | date('mediumDate') }}</span>
+					</div>
+
+					<hr v-if="!message.dateSplit && !message.combine" class="-hr" />
+
+					<app-chat-window-output-item
+						:message="message"
+						:room="room"
+						:is-new="isNewMessage(message)"
+					/>
 				</div>
-
-				<hr v-if="!message.dateSplit && !message.combine" class="-hr" />
-
-				<app-chat-window-output-item
-					:message="message"
-					:room="room"
-					:is-new="isNewMessage(message)"
-				/>
 			</div>
 
 			<transition name="fade">

--- a/src/app/components/chat/window/send/form/form.ts
+++ b/src/app/components/chat/window/send/form/form.ts
@@ -14,10 +14,8 @@ import AppFormControlContent from '../../../../../../_common/form-vue/control/co
 import AppForm from '../../../../../../_common/form-vue/form';
 import { BaseForm } from '../../../../../../_common/form-vue/form.service';
 import { FormValidatorContentNoMediaUpload } from '../../../../../../_common/form-vue/validators/content_no_media_upload';
-import { AppObserveDimensions } from '../../../../../../_common/observe-dimensions/observe-dimensions.directive';
 import { Screen } from '../../../../../../_common/screen/screen-service';
 import AppShortkey from '../../../../../../_common/shortkey/shortkey.vue';
-import { EventBus } from '../../../../../../_common/system/event/event-bus.service';
 import { AppTooltip } from '../../../../../../_common/tooltip/tooltip-directive';
 import { ChatClient, ChatKey, setMessageEditing, startTyping, stopTyping } from '../../../client';
 import { ChatMessage, CHAT_MESSAGE_MAX_CONTENT_LENGTH } from '../../../message';
@@ -37,7 +35,6 @@ export type FormModel = {
 	},
 	directives: {
 		AppTooltip,
-		AppObserveDimensions,
 	},
 })
 export default class AppChatWindowSendForm extends BaseForm<FormModel> {
@@ -73,6 +70,9 @@ export default class AppChatWindowSendForm extends BaseForm<FormModel> {
 
 	@Emit('single-line-mode-change')
 	emitSingleLineModeChange(_singleLine: boolean) {}
+
+	@Emit('size-change')
+	emitSizeChange() {}
 
 	get contentEditorTempResourceContextData() {
 		if (this.chat && this.chat.room) {
@@ -244,7 +244,7 @@ export default class AppChatWindowSendForm extends BaseForm<FormModel> {
 		await this.$nextTick();
 		if (!wasShifted && this.shouldShiftEditor) {
 			// We want to emit this event here too, to make sure we scroll down when the controls pop up on mobile.
-			this.onInputResize();
+			this.emitSizeChange();
 		}
 	}
 
@@ -256,10 +256,6 @@ export default class AppChatWindowSendForm extends BaseForm<FormModel> {
 		if (!this.isEditorFocused) {
 			this.$refs.editor.focus();
 		}
-	}
-
-	onInputResize() {
-		EventBus.emit('Chat.inputResize');
 	}
 
 	onUpKeyPressed(event: KeyboardEvent) {

--- a/src/app/components/chat/window/send/form/form.vue
+++ b/src/app/components/chat/window/send/form/form.vue
@@ -30,7 +30,6 @@
 			<div class="-input">
 				<app-form-control-content
 					ref="editor"
-					v-app-observe-dimensions="onInputResize"
 					:content-context="contentContext"
 					:temp-resource-context-data="contentEditorTempResourceContextData"
 					:placeholder="placeholder"

--- a/src/app/components/chat/window/send/send.ts
+++ b/src/app/components/chat/window/send/send.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component, InjectReactive, Prop, Watch } from 'vue-property-decorator';
+import { Component, Emit, InjectReactive, Prop, Watch } from 'vue-property-decorator';
 import { propRequired } from '../../../../../utils/vue';
 import { ContentDocument } from '../../../../../_common/content/content-document';
 import { AppContentEditorLazy } from '../../../../../_common/content/content-editor/content-editor-lazy';
@@ -24,6 +24,9 @@ import AppChatWindowSendForm from './form/form.vue';
 export default class AppChatWindowSend extends Vue {
 	@InjectReactive(ChatKey) chat!: ChatClient;
 	@Prop(propRequired(ChatRoom)) room!: ChatRoom;
+
+	@Emit('size-change')
+	emitSizeChange() {}
 
 	singleLineMode = true;
 
@@ -80,5 +83,9 @@ export default class AppChatWindowSend extends Vue {
 	@Watch('room.id')
 	async onRoomChanged() {
 		setMessageEditing(this.chat, null);
+	}
+
+	onFormSizeChanged() {
+		this.emitSizeChange();
 	}
 }

--- a/src/app/components/chat/window/send/send.vue
+++ b/src/app/components/chat/window/send/send.vue
@@ -10,6 +10,7 @@
 				@submit="submit($event)"
 				@cancel="onFormCancel"
 				@single-line-mode-change="onSingleLineModeChanged($event)"
+				@size-change="onFormSizeChanged"
 			/>
 		</div>
 	</div>

--- a/src/app/components/chat/window/window.ts
+++ b/src/app/components/chat/window/window.ts
@@ -4,6 +4,7 @@ import { Action } from 'vuex-class';
 import { propRequired } from '../../../../utils/vue';
 import AppFadeCollapse from '../../../../_common/fade-collapse/fade-collapse.vue';
 import { number } from '../../../../_common/filters/number';
+import { AppObserveDimensions } from '../../../../_common/observe-dimensions/observe-dimensions.directive';
 import { Screen } from '../../../../_common/screen/screen-service';
 import AppScrollScroller from '../../../../_common/scroll/scroller/scroller.vue';
 import { SettingChatGroupShowMembers } from '../../../../_common/settings/settings.service';
@@ -16,6 +17,7 @@ import { ChatMessage } from '../message';
 import { ChatRoom, getChatRoomTitle } from '../room';
 import AppChatUserOnlineStatus from '../user-online-status/user-online-status.vue';
 import AppChatWindowMenu from './menu/menu.vue';
+import AppChatWindowOutputTS from './output/output';
 import AppChatWindowOutput from './output/output.vue';
 import AppChatWindowSend from './send/send.vue';
 
@@ -31,6 +33,7 @@ import AppChatWindowSend from './send/send.vue';
 	},
 	directives: {
 		AppTooltip,
+		AppObserveDimensions,
 	},
 })
 export default class AppChatWindow extends Vue {
@@ -47,6 +50,10 @@ export default class AppChatWindow extends Vue {
 	friendAddJolticonVersion = 1;
 
 	readonly Screen = Screen;
+
+	$refs!: {
+		output: AppChatWindowOutputTS[];
+	};
 
 	get users() {
 		return this.chat.roomMembers[this.room.id];
@@ -102,6 +109,14 @@ export default class AppChatWindow extends Vue {
 
 		if (!Screen.isXs) {
 			SettingChatGroupShowMembers.set(this.isShowingUsers);
+		}
+	}
+
+	onSendResize() {
+		// See vue file for why output is an array rather than just a single component.
+		if (this.$refs.output && this.$refs.output.length > 0) {
+			const output = this.$refs.output[0];
+			output.tryAutoscroll();
 		}
 	}
 }

--- a/src/app/components/chat/window/window.vue
+++ b/src/app/components/chat/window/window.vue
@@ -108,6 +108,7 @@
 					<app-chat-window-output
 						v-for="room of [room]"
 						:key="room.id"
+						ref="output"
 						class="chat-window-output-inner"
 						:room="room"
 						:messages="messages"
@@ -116,7 +117,11 @@
 				</div>
 
 				<div v-if="chat.currentUser" class="chat-window-send-container">
-					<app-chat-window-send :room="room" />
+					<app-chat-window-send
+						v-app-observe-dimensions="onSendResize"
+						:room="room"
+						@size-change="onSendResize"
+					/>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fixes the chat's autoscroll behavior, particularly with images/gifs.
These were caused because image/gif inserts would rapidly change the height of the input (because of the image loading in). These happen independent of the vue ticks, so we couldn't easily separate action frames (wait on resize -> check autoscroll).
Because of that, it would determine that the user must've scrolled, so we disabled autoscroll.
The solution is to buffer the scroll handler by 50ms so that rapid fire height changes would be caught by the same autoscroll check.

Also did some cleanup for event handling, and using emit instead of EventBus.