### PR TITLE
Fix display of long data-store keys

### DIFF
--- a/src/_common/game/data-store/item/item.model.ts
+++ b/src/_common/game/data-store/item/item.model.ts
@@ -23,6 +23,11 @@ export class GameDataStoreItem extends Model {
 			'/web/dash/developer/games/api/data-storage/remove-item/' + this.game_id + '/' + this.id
 		);
 	}
+
+	get shortenedKey() {
+		const maxLength : number = 50
+		return this.key.length > maxLength ? this.key.substring(0, maxLength).concat("...") : this.key
+	}
 }
 
 Model.create(GameDataStoreItem);

--- a/src/app/views/dashboard/games/manage/api/data-storage/items/list/list.vue
+++ b/src/app/views/dashboard/games/manage/api/data-storage/items/list/list.vue
@@ -53,7 +53,7 @@
 									params: { item: item.id },
 								}"
 							>
-								<code>{{ item.key }}</code>
+								<code>{{ item.shortenedKey }}</code>
 							</router-link>
 						</td>
 						<td class="small">

--- a/src/app/views/dashboard/games/manage/api/data-storage/items/view/view.ts
+++ b/src/app/views/dashboard/games/manage/api/data-storage/items/view/view.ts
@@ -1,5 +1,6 @@
 import { Component } from 'vue-property-decorator';
 import { Api } from '../../../../../../../../../_common/api/api.service';
+import { Clipboard } from '../../../../../../../../../_common/clipboard/clipboard-service';
 import { date } from '../../../../../../../../../_common/filters/date';
 import { GameDataStoreItem } from '../../../../../../../../../_common/game/data-store/item/item.model';
 import { ModalConfirm } from '../../../../../../../../../_common/modal/confirm/confirm-service';
@@ -55,5 +56,9 @@ export default class RouteDashGamesManageApiDataStorageItemsView extends BaseRou
 
 		await this.item.$remove();
 		this.$router.push({ name: 'dash.games.manage.api.data-storage.items.list' });
+	}
+
+	copyKey() {
+		Clipboard.copy(this.item.key)
 	}
 }

--- a/src/app/views/dashboard/games/manage/api/data-storage/items/view/view.vue
+++ b/src/app/views/dashboard/games/manage/api/data-storage/items/view/view.vue
@@ -19,7 +19,8 @@
 							<translate>dash.games.data_store.items.view.key_label</translate>
 						</th>
 						<td>
-							<code>{{ item.key }}</code>
+							<code @click="copyKey">{{ item.shortenedKey }}</code>
+							(<translate>Click to copy the key</translate>)
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
My suggestion on how to fix this.

Before

![grafik](https://user-images.githubusercontent.com/27819706/119446703-28c45480-bd2f-11eb-9e58-a1299ac080a5.png)
![grafik](https://user-images.githubusercontent.com/27819706/119446742-34b01680-bd2f-11eb-9876-a6996ad94a01.png)

After

![grafik](https://user-images.githubusercontent.com/27819706/119447835-c409f980-bd30-11eb-97dd-2391de6995b5.png)
![grafik](https://user-images.githubusercontent.com/27819706/119448774-10a20480-bd32-11eb-870a-fb6da1308d5e.png)


-------------

The length for the shortenedKey function could also be configurable to allow longer keys on the details page / view.
And you could replace the `<code>`-onClick with an actual copy button, but I'm no UX expert ^^

An alternative would be to use CSS instead of JS using `text-overflow: ellipsis;`. Then you would not need to specifiy the string length manually.

If you want me to, I'll change the PR accordingly.

-----------

Fixes gamejolt/issue-tracker#774
