### PR TITLE
 Fix iOS Safari making videos fullscreen on play

### DIFF
--- a/src/_common/video/player/controller.ts
+++ b/src/_common/video/player/controller.ts
@@ -58,6 +58,10 @@ export class VideoPlayerController {
 	 * through external methods and going fullscreen with their controls.
 	 */
 	get altControlsBehavior() {
+		if (GJ_IS_SSR) {
+			return false;
+		}
+
 		return !document.fullscreenEnabled;
 	}
 

--- a/src/_common/video/player/player.ts
+++ b/src/_common/video/player/player.ts
@@ -318,7 +318,15 @@ export default class AppVideoPlayer extends Vue {
 	syncWithState() {
 		if (this.player.queuedFullScreenChange !== null) {
 			if (this.player.queuedFullScreenChange) {
-				this.$el.requestFullscreen();
+				if (this.player.altControlsBehavior) {
+					const video: any = this.$el.getElementsByTagName('video')[0];
+					// iOS Safari doesn't allow us to go fullscreen through our
+					// preferred way, so we need to use their fullscreen method
+					// and player controls instead.
+					video?.webkitEnterFullscreen();
+				} else {
+					this.$el.requestFullscreen();
+				}
 			} else {
 				document.exitFullscreen();
 			}

--- a/src/_common/video/player/player.ts
+++ b/src/_common/video/player/player.ts
@@ -319,7 +319,7 @@ export default class AppVideoPlayer extends Vue {
 		if (this.player.queuedFullScreenChange !== null) {
 			if (this.player.queuedFullScreenChange) {
 				if (this.player.altControlsBehavior) {
-					const video: any = this.$el.getElementsByTagName('video')[0];
+					const video: any = this.$el.querySelector('video');
 					// iOS Safari doesn't allow us to go fullscreen through our
 					// preferred way, so we need to use their fullscreen method
 					// and player controls instead.

--- a/src/_common/video/player/volume/volume.ts
+++ b/src/_common/video/player/volume/volume.ts
@@ -3,7 +3,10 @@ import { Component, Prop } from 'vue-property-decorator';
 import { propOptional, propRequired } from '../../../../utils/vue';
 import AppPopper from '../../../popper/popper.vue';
 import { Screen } from '../../../screen/screen-service';
-import { SettingVideoPlayerMuted } from '../../../settings/settings.service';
+import {
+	SettingVideoPlayerFeedMuted,
+	SettingVideoPlayerMuted,
+} from '../../../settings/settings.service';
 import { AppTooltip } from '../../../tooltip/tooltip-directive';
 import { setVideoMuted, trackVideoPlayerEvent, VideoPlayerController } from '../controller';
 import AppPlayerSlider from '../slider/slider.vue';
@@ -24,7 +27,14 @@ export default class AppPlayerVolume extends Vue {
 	readonly Screen = Screen;
 
 	onClickMute() {
-		setVideoMuted(this.player, !SettingVideoPlayerMuted.get());
+		let currentState = true;
+		if (this.player.context == 'feed') {
+			currentState = SettingVideoPlayerFeedMuted.get();
+		} else if (this.player.context == 'page') {
+			currentState = SettingVideoPlayerMuted.get();
+		}
+
+		setVideoMuted(this.player, !currentState);
 		trackVideoPlayerEvent(
 			this.player,
 			!this.player.volume || this.player.muted ? 'mute' : 'unmute',

--- a/src/_common/video/player/volume/volume.ts
+++ b/src/_common/video/player/volume/volume.ts
@@ -27,7 +27,7 @@ export default class AppPlayerVolume extends Vue {
 		setVideoMuted(this.player, !SettingVideoPlayerMuted.get());
 		trackVideoPlayerEvent(
 			this.player,
-			!this.player.volume ? 'mute' : 'unmute',
+			!this.player.volume || this.player.muted ? 'mute' : 'unmute',
 			'click-control'
 		);
 	}

--- a/src/_common/video/player/volume/volume.vue
+++ b/src/_common/video/player/volume/volume.vue
@@ -3,7 +3,7 @@
 <template>
 	<div class="-container">
 		<div class="player-control-button" @click="onClickMute">
-			<app-jolticon :icon="player.volume > 0 ? 'audio' : 'audio-mute'" />
+			<app-jolticon :icon="player.volume === 0 || player.muted ? 'audio-mute' : 'audio'" />
 		</div>
 
 		<app-player-slider v-if="!Screen.isMobile && hasSlider" :player="player" />


### PR DESCRIPTION
- Allows Game Jolt videos to be played without going fullscreen in iOS Safari.
- Going fullscreen in iOS Safari will now open through the browser implementation.
- Adds better mute handling/syncing for iOS Safari fullscreen controls.