### PR TITLE
Community fireside allow collaborators

### DIFF
--- a/src/_common/community/community.model.ts
+++ b/src/_common/community/community.model.ts
@@ -292,3 +292,15 @@ export function canCommunityFeatureFireside(community: Community) {
 export function canCommunityEjectFireside(community: Community) {
 	return !!community.hasPerms('community-firesides');
 }
+
+export function canCreateFiresides(community: Community) {
+	if (community.hasPerms('community-firesides')) {
+		return true;
+	}
+
+	if (community.isBlocked) {
+		return false;
+	}
+
+	return community.allow_firesides;
+}

--- a/src/app/views/communities/view/overview/overview.ts
+++ b/src/app/views/communities/view/overview/overview.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, Watch } from 'vue-property-decorator';
 import { Action, State } from 'vuex-class';
 import { arrayRemove } from '../../../../../utils/array';
+import { canCreateFiresides } from '../../../../../_common/community/community.model';
 import { Fireside } from '../../../../../_common/fireside/fireside.model';
 import { FiresidePost } from '../../../../../_common/fireside/post/post-model';
 import { Growls } from '../../../../../_common/growls/growls.service';
@@ -97,7 +98,7 @@ export default class RouteCommunitiesViewOverview extends BaseRouteComponent {
 	}
 
 	get canCreateFireside() {
-		return !this.userFireside && this.community.allow_firesides && !this.community.isBlocked;
+		return canCreateFiresides(this.community);
 	}
 
 	get firesidesGridColumns() {


### PR DESCRIPTION
Allows collaborators ("Equal Collaborators", those with "community-firesides" perms) to create Firesides in a community that has `allow_firesides` disabled.