### PR TITLE
Improve fireside screen design

### DIFF
--- a/src/_common/fireside/rtc/rtc.ts
+++ b/src/_common/fireside/rtc/rtc.ts
@@ -117,7 +117,11 @@ export class FiresideRTC {
 	}
 
 	get shouldShowVolumeControls() {
-		return this.focusedUser?.hasDesktopAudio === true && !this.isFocusingMe;
+		return (
+			this.focusedUser?.hasDesktopAudio === true &&
+			this.focusedUser?.hasVideo === true &&
+			!this.isFocusingMe
+		);
 	}
 
 	get isFocusingMe() {

--- a/src/_common/fireside/rtc/user.ts
+++ b/src/_common/fireside/rtc/user.ts
@@ -58,6 +58,7 @@ export class FiresideRTCUser {
 	readonly videoLocks: FiresideVideoLock[] = [];
 
 	hasDesktopAudio = false;
+	pausedFrameData: ImageData | null = null;
 
 	hasMicAudio = false;
 	micAudioMuted = false;
@@ -202,6 +203,7 @@ export async function setVideoPlayback(user: FiresideRTCUser, newState: Fireside
 		try {
 			if (user._videoTrack?.isPlaying) {
 				try {
+					user.pausedFrameData = user._videoTrack.getCurrentFrameData();
 					user._videoTrack.stop();
 				} catch (e) {
 					rtc.logWarning(

--- a/src/app/components/chat/window/send/form/form.ts
+++ b/src/app/components/chat/window/send/form/form.ts
@@ -63,6 +63,7 @@ export default class AppChatWindowSendForm extends BaseForm<FormModel> {
 	@Emit('submit') emitSubmit(_content: FormModel) {}
 	@Emit('cancel') emitCancel() {}
 	@Emit('single-line-mode-change') emitSingleLineModeChange(_singleLine: boolean) {}
+	@Emit('focus-change') emitFocusChange(_focused: boolean) {}
 
 	get chat() {
 		return this.chatStore.chat!;
@@ -288,10 +289,12 @@ export default class AppChatWindowSendForm extends BaseForm<FormModel> {
 
 	onFocusEditor() {
 		this.isEditorFocused = true;
+		this.emitFocusChange(true);
 	}
 
 	onBlurEditor() {
 		this.isEditorFocused = false;
+		this.emitFocusChange(false);
 	}
 
 	onTabKeyPressed() {

--- a/src/app/components/chat/window/send/send.ts
+++ b/src/app/components/chat/window/send/send.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component, InjectReactive, Prop, Watch } from 'vue-property-decorator';
+import { Component, Emit, InjectReactive, Prop, Watch } from 'vue-property-decorator';
 import { propRequired } from '../../../../../utils/vue';
 import { ContentDocument } from '../../../../../_common/content/content-document';
 import { AppContentEditorLazy } from '../../../../../_common/content/content-editor/content-editor-lazy';
@@ -23,6 +23,8 @@ export default class AppChatWindowSend extends Vue {
 	singleLineMode = true;
 
 	readonly Screen = Screen;
+
+	@Emit('focus-change') emitFocusChange(_focused: boolean) {}
 
 	get chat() {
 		return this.chatStore.chat!;

--- a/src/app/components/chat/window/send/send.vue
+++ b/src/app/components/chat/window/send/send.vue
@@ -10,6 +10,7 @@
 				@submit="submit($event)"
 				@cancel="onFormCancel"
 				@single-line-mode-change="onSingleLineModeChanged($event)"
+				@focus-change="emitFocusChange"
 			/>
 		</div>
 	</div>

--- a/src/app/components/chat/window/window.ts
+++ b/src/app/components/chat/window/window.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component, InjectReactive, Prop } from 'vue-property-decorator';
+import { Component, Emit, InjectReactive, Prop } from 'vue-property-decorator';
 import { Action } from 'vuex-class';
 import { propRequired } from '../../../../utils/vue';
 import AppFadeCollapse from '../../../../_common/fade-collapse/fade-collapse.vue';
@@ -50,6 +50,8 @@ export default class AppChatWindow extends Vue {
 	friendAddJolticonVersion = 1;
 
 	readonly Screen = Screen;
+
+	@Emit('focus-change') emitFocusChange(_focused: boolean) {}
 
 	get chat() {
 		return this.chatStore.chat!;

--- a/src/app/components/chat/window/window.vue
+++ b/src/app/components/chat/window/window.vue
@@ -127,7 +127,7 @@
 				</div>
 
 				<div v-if="chat.currentUser" class="chat-window-send-container">
-					<app-chat-window-send :room="room" />
+					<app-chat-window-send :room="room" @focus-change="emitFocusChange" />
 				</div>
 			</div>
 		</div>

--- a/src/app/components/fireside/stream/video/video.ts
+++ b/src/app/components/fireside/stream/video/video.ts
@@ -23,7 +23,6 @@ export default class AppFiresideStreamVideo extends Vue {
 	private _myRtcUser!: FiresideRTCUser;
 	private _videoLock: FiresideVideoLock | null = null;
 
-	$el!: HTMLDivElement;
 	$refs!: {
 		video: HTMLDivElement;
 		canvas: HTMLCanvasElement;
@@ -54,6 +53,7 @@ export default class AppFiresideStreamVideo extends Vue {
 
 	mounted() {
 		this.onShouldPlayVideoChange();
+		this.onFrameDataChange();
 	}
 
 	destroyed() {
@@ -79,7 +79,7 @@ export default class AppFiresideStreamVideo extends Vue {
 	}
 
 	@Watch('pausedFrameData')
-	private async onFrameDataChange() {
+	private onFrameDataChange() {
 		if (this.pausedFrameData) {
 			const {
 				$refs: { canvas },
@@ -89,6 +89,7 @@ export default class AppFiresideStreamVideo extends Vue {
 			canvas.width = width;
 			canvas.height = height;
 			const context = canvas.getContext('2d')!;
+			context.clearRect(0, 0, width, height);
 			context.putImageData(this.pausedFrameData, 0, 0, 0, 0, width, height);
 		}
 	}

--- a/src/app/components/fireside/stream/video/video.vue
+++ b/src/app/components/fireside/stream/video/video.vue
@@ -2,16 +2,12 @@
 
 <template>
 	<div class="-video-player">
-		<div ref="video" :class="{ '-hide': !shouldPlayVideo }" />
-		<canvas ref="canvas" :class="{ '-hide': shouldPlayVideo }" />
+		<div ref="video" />
+		<canvas v-show="!shouldPlayVideo" ref="canvas" />
 	</div>
 </template>
 
 <style lang="stylus" scoped>
-.-hide
-	display: none
-	visibility: hidden
-
 .-video-player
 	position: relative
 

--- a/src/app/components/fireside/stream/video/video.vue
+++ b/src/app/components/fireside/stream/video/video.vue
@@ -1,11 +1,25 @@
 <script lang="ts" src="./video"></script>
 
 <template>
-	<div class="-video-player" />
+	<div class="-video-player">
+		<div ref="video" :class="{ '-hide': !shouldPlayVideo }" />
+		<canvas ref="canvas" :class="{ '-hide': shouldPlayVideo }" />
+	</div>
 </template>
 
 <style lang="stylus" scoped>
+.-hide
+	display: none
+	visibility: hidden
+
 .-video-player
-	width: 100%
-	height: 100%
+	position: relative
+
+	&
+	> *
+		width: 100%
+		height: 100%
+
+	> *
+		position: absolute
 </style>

--- a/src/app/views/fireside/_header/header.vue
+++ b/src/app/views/fireside/_header/header.vue
@@ -1,10 +1,13 @@
 <script lang="ts" src="./header"></script>
 
 <template>
-	<div class="fireside-header">
+	<div class="fireside-header" :class="{ '-overlay': isOverlay }">
 		<template v-if="fireside">
 			<div class="-fireside-title">
-				<h2 class="sans-margin-top" :class="{ h3: Screen.isXs }">
+				<h2
+					class="sans-margin-top"
+					:class="{ h3: Screen.isXs, 'sans-margin-bottom': isOverlay }"
+				>
 					<small class="-subtitle">
 						<router-link
 							:to="{
@@ -41,7 +44,9 @@
 							<translate>Featured</translate>
 						</span>
 					</small>
-					<div :title="fireside.title">{{ fireside.title }}</div>
+					<div class="-fireside-title-text" :title="fireside.title">
+						{{ fireside.title }}
+					</div>
 				</h2>
 				<div v-if="hasChatStats && c.chatUsers" class="-fireside-title-member-stats">
 					<ul class="stat-list">
@@ -69,134 +74,11 @@
 						/>
 					</div>
 
-					<app-popper
-						popover-class="fill-darkest"
-						@show="onShowPopper"
-						@hide="onHidePopper"
-					>
+					<app-fireside-settings-popper @show="onShowPopper" @hide="onHidePopper">
 						<div class="-stats-btn">
-							<app-button icon="cog" circle sparse solid />
+							<app-button icon="ellipsis-v" circle sparse solid />
 						</div>
-
-						<template #popover>
-							<div class="list-group list-group-dark">
-								<a
-									v-if="!fireside.is_draft"
-									class="list-group-item has-icon"
-									@click="onClickCopyLink"
-								>
-									<app-jolticon icon="link" />
-									<translate>Copy Link</translate>
-								</a>
-
-								<a
-									v-if="hasChat"
-									class="list-group-item has-icon"
-									@click="onClickShowChatMembers"
-								>
-									<app-jolticon icon="users" />
-									<translate>Chat Members</translate>
-								</a>
-
-								<a
-									v-if="c.canReport"
-									class="list-group-item has-icon"
-									@click="onClickReport"
-								>
-									<app-jolticon icon="flag" />
-									<translate>Report Fireside</translate>
-								</a>
-
-								<a
-									v-if="canEdit"
-									class="list-group-item has-icon"
-									@click="onClickEditFireside"
-								>
-									<app-jolticon icon="edit" />
-									<translate>Edit Fireside</translate>
-								</a>
-
-								<a
-									v-if="c.canManageCohosts"
-									class="list-group-item has-icon"
-									@click="onClickManageCohosts"
-								>
-									<app-jolticon icon="friends" />
-									<translate>Manage Hosts</translate>
-								</a>
-
-								<template v-if="shouldShowStreamSettings">
-									<a class="list-group-item has-icon" @click="onClickEditStream">
-										<app-jolticon icon="broadcast" />
-										<translate>Stream Settings</translate>
-									</a>
-								</template>
-
-								<template v-if="c.canPublish">
-									<hr />
-									<a class="list-group-item has-icon" @click="onClickPublish">
-										<app-jolticon icon="notifications" highlight />
-										<translate>Publish Fireside</translate>
-									</a>
-								</template>
-
-								<template v-if="shouldShowStreamSettings || c.canExtinguish">
-									<hr />
-
-									<a
-										v-if="shouldShowStreamSettings"
-										class="list-group-item has-icon"
-										@click="onClickStopStreaming"
-									>
-										<app-jolticon icon="plug" notice />
-										<translate>Stop Streaming</translate>
-									</a>
-
-									<a
-										v-if="c.canExtinguish"
-										class="list-group-item has-icon"
-										@click="onClickExtinguish"
-									>
-										<app-jolticon icon="remove" notice />
-										<translate>Extinguish Fireside</translate>
-									</a>
-								</template>
-
-								<template v-if="!fireside.is_draft">
-									<div v-for="i in manageableCommunities" :key="i.id">
-										<hr />
-
-										<h5 class="-extras-header list-group-item has-icon">
-											<app-community-thumbnail-img :community="i.community" />
-											{{ i.community.name }}
-										</h5>
-
-										<!--DISABLED_ALLOW_FIRESIDES -->
-										<!-- <a
-											class="list-group-item has-icon"
-											@click="toggleFeatured(i)"
-										>
-											<app-jolticon icon="star" />
-
-											<translate v-if="i.isFeatured">
-												Unfeature fireside
-											</translate>
-											<translate v-else>Feature fireside</translate>
-										</a> -->
-
-										<a
-											class="list-group-item has-icon"
-											@click="ejectFireside(i)"
-										>
-											<app-jolticon icon="eject" />
-
-											<translate>Eject fireside</translate>
-										</a>
-									</div>
-								</template>
-							</div>
-						</template>
-					</app-popper>
+					</app-fireside-settings-popper>
 				</div>
 			</div>
 		</template>
@@ -207,10 +89,22 @@
 @import '~styles/variables'
 @import '~styles-lib/mixins'
 
+.-overlay
+	*
+		text-shadow: 1px 1px 3px rgba($black, 0.5)
+
+		&:not(a)
+			color: white
+
+	.-subtitle
+		font-weight: 600
+		opacity: 0.75
+
 .-fireside-title
 	display: flex
 	align-items: center
 
+	&-text
 	h2
 		text-overflow()
 		flex: auto

--- a/src/app/views/fireside/_host-list/host-list.ts
+++ b/src/app/views/fireside/_host-list/host-list.ts
@@ -30,18 +30,18 @@ import AppFiresideHostListStickerButton from './sticker-button/sticker-button.vu
 	},
 })
 export default class AppFiresideHostList extends Vue {
-	@Prop({ type: Boolean, required: false, default: false })
+	@Prop({ type: Boolean, default: false })
 	hideThumbOptions!: boolean;
 
 	@InjectReactive(FiresideControllerKey) c!: FiresideController;
 	@Inject(DrawerStoreKey) drawerStore!: DrawerStore;
 
+	@Emit('show-popper') emitShowPopper() {}
+	@Emit('hide-popper') emitHidePopper() {}
+
 	get canPlaceStickers() {
 		return !GJ_IS_CLIENT && !!this.c.user && !Screen.isMobile;
 	}
-
-	@Emit('show-popper') emitShowPopper() {}
-	@Emit('hide-popper') emitHidePopper() {}
 
 	get canManageCohosts() {
 		return this.c.canManageCohosts;

--- a/src/app/views/fireside/_host-list/host-list.vue
+++ b/src/app/views/fireside/_host-list/host-list.vue
@@ -35,15 +35,17 @@
 
 .-fireside-hosts
 	--fireside-host-size: 100px
+	--fireside-host-gap: 8px
 	width: 100%
 
-	@media $media-xs
-		--fireside-host-size: 70px
+	@media $media-mobile
+		--fireside-host-size: 60px
+		--fireside-host-gap: 4px
 
 	&-inner
 		display: inline-flex
 		justify-content: center
-		grid-gap: 8px
+		grid-gap: var(--fireside-host-gap)
 		height: var(--fireside-host-size)
 
 .-host-thumb

--- a/src/app/views/fireside/_settings-popper/settings-popper.ts
+++ b/src/app/views/fireside/_settings-popper/settings-popper.ts
@@ -106,6 +106,7 @@ export default class AppFiresideSettingsPopper extends Vue {
 			return;
 		}
 
+		Popper.hideAll();
 		stopStreaming(this.c.rtc.producer);
 	}
 

--- a/src/app/views/fireside/_settings-popper/settings-popper.ts
+++ b/src/app/views/fireside/_settings-popper/settings-popper.ts
@@ -1,0 +1,163 @@
+import Vue from 'vue';
+import { Component, Emit, InjectReactive } from 'vue-property-decorator';
+import { Api } from '../../../../_common/api/api.service';
+import AppCommunityThumbnailImg from '../../../../_common/community/thumbnail/img/img.vue';
+import { FiresideCommunity } from '../../../../_common/fireside/community/community.model';
+import { stopStreaming } from '../../../../_common/fireside/rtc/producer';
+import { setAudioPlayback } from '../../../../_common/fireside/rtc/user';
+import { Growls } from '../../../../_common/growls/growls.service';
+import { Popper } from '../../../../_common/popper/popper.service';
+import AppPopper from '../../../../_common/popper/popper.vue';
+import { ReportModal } from '../../../../_common/report/modal/modal.service';
+import { CommunityEjectFiresideModal } from '../../../components/community/eject-fireside/modal/modal.service';
+import {
+	copyFiresideLink,
+	extinguishFireside,
+	FiresideController,
+	FiresideControllerKey,
+	publishFireside,
+} from '../../../components/fireside/controller/controller';
+import { StreamSetupModal } from '../../../components/fireside/stream/setup/setup-modal.service';
+import { CohostManageModal } from '../cohost/manage/manage-modal.service';
+import { FiresideChatMembersModal } from '../_chat-members/modal/modal.service';
+import { FiresideEditModal } from '../_edit-modal/edit-modal.service';
+
+@Component({
+	components: {
+		AppPopper,
+		AppCommunityThumbnailImg,
+	},
+})
+export default class AppFiresideSettingsPopper extends Vue {
+	@InjectReactive(FiresideControllerKey)
+	c!: FiresideController;
+
+	@Emit('show') emitShow() {}
+	@Emit('hide') emitHide() {}
+
+	get fireside() {
+		return this.c.fireside;
+	}
+
+	get canEdit() {
+		return this.c.canEdit;
+	}
+
+	get manageableCommunities() {
+		if (!this.fireside) {
+			return [];
+		}
+
+		return this.fireside.community_links.filter(i =>
+			i.community.hasPerms('community-firesides')
+		);
+	}
+
+	get shouldShowStreamSettings() {
+		return this.c.shouldShowStreamingOptions && this.c.isPersonallyStreaming;
+	}
+
+	get shouldMute() {
+		return this.c.rtc?.users.some(i => !i.micAudioMuted) ?? false;
+	}
+
+	muteAll() {
+		return this.c.rtc?.users.forEach(i => setAudioPlayback(i, false));
+	}
+
+	unmuteAll() {
+		return this.c.rtc?.users.forEach(i => setAudioPlayback(i, true));
+	}
+
+	onClickShowChatMembers() {
+		if (!this.c.chatUsers || !this.c.chatRoom) {
+			return;
+		}
+
+		FiresideChatMembersModal.show(this.c.chatUsers, this.c.chatRoom);
+	}
+
+	onClickEditStream() {
+		StreamSetupModal.show(this.c);
+	}
+
+	onClickEditFireside() {
+		FiresideEditModal.show(this.c);
+	}
+
+	onClickManageCohosts() {
+		CohostManageModal.show(this.c);
+	}
+
+	onClickPublish() {
+		publishFireside(this.c);
+	}
+
+	onClickCopyLink() {
+		copyFiresideLink(this.c, this.$router);
+	}
+
+	onClickStopStreaming() {
+		if (!this.c.rtc?.producer) {
+			return;
+		}
+
+		stopStreaming(this.c.rtc.producer);
+	}
+
+	onClickExtinguish() {
+		extinguishFireside(this.c);
+	}
+
+	onClickReport() {
+		ReportModal.show(this.fireside);
+	}
+
+	async toggleFeatured(community: FiresideCommunity) {
+		Popper.hideAll();
+		if (!community.community.hasPerms('community-firesides')) {
+			return;
+		}
+
+		const isFeaturing = !community.isFeatured;
+		try {
+			if (isFeaturing) {
+				await this.fireside.$feature();
+			} else {
+				await this.fireside.$unfeature();
+			}
+		} catch (_) {
+			Growls.error({
+				message: isFeaturing
+					? this.$gettext('Something went wrong while featuring this fireside...')
+					: this.$gettext('Something went wrong while unfeaturing this fireside...'),
+			});
+		}
+	}
+
+	async ejectFireside(community: FiresideCommunity) {
+		Popper.hideAll();
+		if (!community.community.hasPerms('community-firesides')) {
+			return;
+		}
+
+		const result = await CommunityEjectFiresideModal.show(community, this.fireside);
+		if (!result) {
+			return;
+		}
+
+		try {
+			const response = await Api.sendRequest(
+				`/web/communities/manage/eject-fireside/${community.id}`,
+				result
+			);
+			if (response.fireside) {
+				this.fireside.assign(response.fireside);
+			}
+		} catch (_) {
+			Growls.error({
+				message: this.$gettext('Something went wrong while ejecting this fireside...'),
+			});
+		}
+	}
+}

--- a/src/app/views/fireside/_settings-popper/settings-popper.ts
+++ b/src/app/views/fireside/_settings-popper/settings-popper.ts
@@ -54,7 +54,11 @@ export default class AppFiresideSettingsPopper extends Vue {
 	}
 
 	get shouldShowStreamSettings() {
-		return this.c.shouldShowStreamingOptions && this.c.isPersonallyStreaming;
+		return this.c.shouldShowStreamingOptions;
+	}
+
+	get isStreaming() {
+		return this.c.isPersonallyStreaming;
 	}
 
 	get shouldMute() {

--- a/src/app/views/fireside/_settings-popper/settings-popper.vue
+++ b/src/app/views/fireside/_settings-popper/settings-popper.vue
@@ -1,0 +1,123 @@
+<script lang="ts" src="./settings-popper"></script>
+
+<template>
+	<app-popper popover-class="fill-darkest" @show="emitShow" @hide="emitHide">
+		<slot />
+		<!-- <div class="-stats-btn">
+			<app-button icon="ellipsis-v" circle sparse solid />
+		</div> -->
+
+		<template #popover>
+			<div class="list-group list-group-dark">
+				<a
+					v-if="!fireside.is_draft"
+					class="list-group-item has-icon"
+					@click="onClickCopyLink"
+				>
+					<app-jolticon icon="link" />
+					<translate>Copy Link</translate>
+				</a>
+
+				<a v-if="shouldMute" class="list-group-item" @click="muteAll()">
+					<app-jolticon icon="audio-mute" />
+					<translate>Mute All Users</translate>
+				</a>
+				<a v-else class="list-group-item" @click="unmuteAll()">
+					<app-jolticon icon="audio" />
+					<translate>Unmute All Users</translate>
+				</a>
+
+				<a class="list-group-item has-icon" @click="onClickShowChatMembers">
+					<app-jolticon icon="users" />
+					<translate>Chat Members</translate>
+				</a>
+
+				<a v-if="c.canReport" class="list-group-item has-icon" @click="onClickReport">
+					<app-jolticon icon="flag" />
+					<translate>Report Fireside</translate>
+				</a>
+
+				<a v-if="canEdit" class="list-group-item has-icon" @click="onClickEditFireside">
+					<app-jolticon icon="edit" />
+					<translate>Edit Fireside</translate>
+				</a>
+
+				<a
+					v-if="c.canManageCohosts"
+					class="list-group-item has-icon"
+					@click="onClickManageCohosts"
+				>
+					<app-jolticon icon="friends" />
+					<translate>Manage Hosts</translate>
+				</a>
+
+				<template v-if="shouldShowStreamSettings">
+					<a class="list-group-item has-icon" @click="onClickEditStream">
+						<app-jolticon icon="broadcast" />
+						<translate>Stream Settings</translate>
+					</a>
+				</template>
+
+				<template v-if="c.canPublish">
+					<hr />
+					<a class="list-group-item has-icon" @click="onClickPublish">
+						<app-jolticon icon="notifications" highlight />
+						<translate>Publish Fireside</translate>
+					</a>
+				</template>
+
+				<template v-if="shouldShowStreamSettings || c.canExtinguish">
+					<hr />
+
+					<a
+						v-if="shouldShowStreamSettings"
+						class="list-group-item has-icon"
+						@click="onClickStopStreaming"
+					>
+						<app-jolticon icon="plug" notice />
+						<translate>Stop Streaming</translate>
+					</a>
+
+					<a
+						v-if="c.canExtinguish"
+						class="list-group-item has-icon"
+						@click="onClickExtinguish"
+					>
+						<app-jolticon icon="remove" notice />
+						<translate>Extinguish Fireside</translate>
+					</a>
+				</template>
+
+				<template v-if="!fireside.is_draft">
+					<div v-for="i in manageableCommunities" :key="i.id">
+						<hr />
+
+						<h5 class="-extras-header list-group-item has-icon">
+							<app-community-thumbnail-img :community="i.community" />
+							{{ i.community.name }}
+						</h5>
+
+						<!-- DISABLED_ALLOW_FIRESIDES -->
+						<!-- <a class="list-group-item has-icon" @click="toggleFeatured(i)">
+							<app-jolticon icon="star" />
+
+							<translate v-if="i.isFeatured"> Unfeature fireside </translate>
+							<translate v-else>Feature fireside</translate>
+						</a> -->
+
+						<a class="list-group-item has-icon" @click="ejectFireside(i)">
+							<app-jolticon icon="eject" />
+
+							<translate>Eject fireside</translate>
+						</a>
+					</div>
+				</template>
+			</div>
+		</template>
+	</app-popper>
+</template>
+
+<style lang="stylus" scoped>
+@import '~styles/variables'
+@import '~styles-lib/mixins'
+</style>

--- a/src/app/views/fireside/_settings-popper/settings-popper.vue
+++ b/src/app/views/fireside/_settings-popper/settings-popper.vue
@@ -3,9 +3,6 @@
 <template>
 	<app-popper popover-class="fill-darkest" @show="emitShow" @hide="emitHide">
 		<slot />
-		<!-- <div class="-stats-btn">
-			<app-button icon="ellipsis-v" circle sparse solid />
-		</div> -->
 
 		<template #popover>
 			<div class="list-group list-group-dark">
@@ -54,7 +51,8 @@
 				<template v-if="shouldShowStreamSettings">
 					<a class="list-group-item has-icon" @click="onClickEditStream">
 						<app-jolticon icon="broadcast" />
-						<translate>Stream Settings</translate>
+						<translate v-if="isStreaming">Stream Settings</translate>
+						<translate v-else>Start Stream / Voice Chat</translate>
 					</a>
 				</template>
 
@@ -66,11 +64,11 @@
 					</a>
 				</template>
 
-				<template v-if="shouldShowStreamSettings || c.canExtinguish">
+				<template v-if="isStreaming || c.canExtinguish">
 					<hr />
 
 					<a
-						v-if="shouldShowStreamSettings"
+						v-if="isStreaming"
 						class="list-group-item has-icon"
 						@click="onClickStopStreaming"
 					>

--- a/src/app/views/fireside/_stream-options/stream-options.ts
+++ b/src/app/views/fireside/_stream-options/stream-options.ts
@@ -1,11 +1,6 @@
 import Vue from 'vue';
 import { Component, Emit, InjectReactive } from 'vue-property-decorator';
 import { stopStreaming } from '../../../../_common/fireside/rtc/producer';
-import { setRTCDesktopVolume } from '../../../../_common/fireside/rtc/rtc';
-import { setAudioPlayback } from '../../../../_common/fireside/rtc/user';
-import AppPopper from '../../../../_common/popper/popper.vue';
-import { ScrubberCallback } from '../../../../_common/slider/slider';
-import AppSlider from '../../../../_common/slider/slider.vue';
 import { AppState, AppStore } from '../../../../_common/store/app-store';
 import { AppTooltip } from '../../../../_common/tooltip/tooltip-directive';
 import {
@@ -13,11 +8,11 @@ import {
 	FiresideControllerKey,
 } from '../../../components/fireside/controller/controller';
 import { StreamSetupModal } from '../../../components/fireside/stream/setup/setup-modal.service';
+import AppFiresideSettingsPopper from '../_settings-popper/settings-popper.vue';
 
 @Component({
 	components: {
-		AppPopper,
-		AppSlider,
+		AppFiresideSettingsPopper,
 	},
 	directives: {
 		AppTooltip,
@@ -32,30 +27,6 @@ export default class AppFiresideStreamOptions extends Vue {
 	@Emit('show-popper') emitShowPopper() {}
 	@Emit('hide-popper') emitHidePopper() {}
 
-	get desktopVolume() {
-		return this.c.rtc?.desktopVolume ?? 1;
-	}
-
-	get shouldShowVolumeControls() {
-		return !!this.c.rtc?.shouldShowVolumeControls;
-	}
-
-	get shouldShowAsMuted() {
-		return this.shouldShowVolumeControls && this.desktopVolume === 0;
-	}
-
-	get shouldMute() {
-		return this.c.rtc?.users.some(i => !i.micAudioMuted) ?? false;
-	}
-
-	muteAll() {
-		return this.c.rtc?.users.forEach(i => setAudioPlayback(i, false));
-	}
-
-	unmuteAll() {
-		return this.c.rtc?.users.forEach(i => setAudioPlayback(i, true));
-	}
-
 	onClickEditStream() {
 		StreamSetupModal.show(this.c);
 	}
@@ -66,9 +37,5 @@ export default class AppFiresideStreamOptions extends Vue {
 		}
 
 		stopStreaming(this.c.rtc.producer);
-	}
-
-	onVolumeScrub({ percent }: ScrubberCallback) {
-		setRTCDesktopVolume(this.c.rtc!, percent);
 	}
 }

--- a/src/app/views/fireside/_stream-options/stream-options.vue
+++ b/src/app/views/fireside/_stream-options/stream-options.vue
@@ -2,93 +2,14 @@
 
 <template>
 	<div class="-options-wrap">
-		<app-popper @show="emitShowPopper" @hide="emitHidePopper">
-			<div v-app-tooltip="$gettext(`Stream Options`)" class="-options">
+		<app-fireside-settings-popper @show="emitShowPopper" @hide="emitHidePopper">
+			<div class="-options">
 				<app-jolticon class="-icon" icon="ellipsis-v" />
-				<app-jolticon v-if="shouldShowAsMuted" class="-muted" icon="audio-mute" />
 			</div>
-
-			<template #popover>
-				<div class="list-group list-group-dark">
-					<template v-if="shouldShowVolumeControls">
-						<h5 class="-header list-group-item has-icon">
-							<app-jolticon :icon="shouldShowAsMuted ? 'audio-mute' : 'audio'" />
-							<translate>Video Volume</translate>
-						</h5>
-						<div class="-volume list-group-item">
-							<app-slider
-								class="-volume-inner"
-								:percent="desktopVolume"
-								@scrub="onVolumeScrub"
-							/>
-						</div>
-					</template>
-
-					<a v-if="shouldMute" class="list-group-item" @click="muteAll()">
-						<app-jolticon icon="audio-mute" />
-						<translate>Mute All Users</translate>
-					</a>
-					<a v-else class="list-group-item" @click="unmuteAll()">
-						<app-jolticon icon="audio" />
-						<translate>Unmute All Users</translate>
-					</a>
-
-					<template v-if="c.shouldShowStreamingOptions">
-						<a
-							v-if="!c.isPersonallyStreaming"
-							class="list-group-item has-icon"
-							@click="onClickEditStream"
-						>
-							<app-jolticon icon="broadcast" />
-							<translate>Start Streaming</translate>
-						</a>
-						<template v-else>
-							<a class="list-group-item has-icon" @click="onClickEditStream">
-								<app-jolticon icon="broadcast" />
-								<translate>Stream Settings</translate>
-							</a>
-							<a class="list-group-item has-icon" @click="onClickStopStreaming">
-								<app-jolticon icon="plug" notice />
-								<translate>Stop Streaming</translate>
-							</a>
-						</template>
-					</template>
-				</div>
-			</template>
-		</app-popper>
+		</app-fireside-settings-popper>
 	</div>
 </template>
 
 <style lang="stylus" scoped>
 @import '../common'
-
-.-options
-	position: relative
-
-.-muted
-	img-circle()
-	position: absolute
-	right: 0
-	bottom: 0
-	padding: 4px
-	background-color: var(--theme-bg-subtle)
-	color: var(--theme-fg)
-
-.-volume
-	display: inline-flex
-	width: 100%
-
-	&-inner
-		flex: 1
-
-.-header
-	font-family: $font-family-heading
-	font-size: $font-size-tiny
-	font-weight: normal
-	letter-spacing: 0.1em
-	line-height: 1
-	text-transform: uppercase
-	margin-top: 0
-	margin-bottom: 0
-	border: 0
 </style>

--- a/src/app/views/fireside/_stream/stream.ts
+++ b/src/app/views/fireside/_stream/stream.ts
@@ -61,6 +61,10 @@ export default class AppFiresideStream extends Vue {
 	hasQueuedStreakAnimation = false;
 	shouldAnimateStreak = false;
 
+	$refs!: {
+		paused?: HTMLDivElement;
+	};
+
 	get stickerStreak() {
 		return this.drawerStore.streak;
 	}
@@ -117,10 +121,15 @@ export default class AppFiresideStream extends Vue {
 	}
 
 	get shouldPlayDesktopAudio() {
+		if (!this.c.rtc) {
+			return false;
+		}
+
 		return (
 			this.hasVideo &&
-			this.c.rtc?.videoChannel.isConnected === true &&
-			this.rtcUser.hasDesktopAudio
+			this.c.rtc.videoChannel.isConnected &&
+			this.rtcUser.hasDesktopAudio &&
+			!this.c.rtc.videoPaused
 		);
 	}
 
@@ -132,16 +141,12 @@ export default class AppFiresideStream extends Vue {
 		this.scheduleUIHide(UIHideTimeoutMovement);
 	}
 
-	onVideoClick() {
+	onVideoClick(event: Event) {
 		this.scheduleUIHide(UIHideTimeout);
 
-		// Don't alter video playback here when we have overlays to use tap
-		// interactions with.
-		if (!this.videoPaused) {
-			return;
+		if (event.target === this.$refs.paused) {
+			this.togglePlayback();
 		}
-
-		this.togglePlayback();
 	}
 
 	onOverlayTap(event: Event) {

--- a/src/app/views/fireside/_stream/stream.ts
+++ b/src/app/views/fireside/_stream/stream.ts
@@ -3,11 +3,13 @@ import { Component, Inject, InjectReactive, Prop, Watch } from 'vue-property-dec
 import { DrawerStore, DrawerStoreKey } from '../../../../_common/drawer/drawer-store';
 import { fuzzynumber } from '../../../../_common/filters/fuzzynumber';
 import { number } from '../../../../_common/filters/number';
+import { setRTCDesktopVolume } from '../../../../_common/fireside/rtc/rtc';
 import { FiresideRTCUser } from '../../../../_common/fireside/rtc/user';
 import AppLoading from '../../../../_common/loading/loading.vue';
 import { Screen } from '../../../../_common/screen/screen-service';
+import { ScrubberCallback } from '../../../../_common/slider/slider';
+import AppSlider from '../../../../_common/slider/slider.vue';
 import AppSticker from '../../../../_common/sticker/sticker.vue';
-import { ChatUserCollection } from '../../../components/chat/user-collection';
 import {
 	FiresideController,
 	FiresideControllerKey,
@@ -15,6 +17,7 @@ import {
 import AppFiresideDesktopAudio from '../../../components/fireside/stream/desktop-audio/desktop-audio.vue';
 import AppFiresideVideoStats from '../../../components/fireside/stream/video-stats/video-stats.vue';
 import AppFiresideVideo from '../../../components/fireside/stream/video/video.vue';
+import AppFiresideHeader from '../_header/header.vue';
 import AppFiresideHostList from '../_host-list/host-list.vue';
 import AppFiresideHostThumbIndicator from '../_host-thumb/host-thumb-indicator.vue';
 
@@ -23,12 +26,14 @@ const UIHideTimeoutMovement = 2000;
 const UITransitionTime = 200;
 @Component({
 	components: {
+		AppFiresideDesktopAudio,
+		AppFiresideHeader,
 		AppFiresideHostList,
 		AppFiresideHostThumbIndicator,
-		AppLoading,
 		AppFiresideVideo,
-		AppFiresideDesktopAudio,
 		AppFiresideVideoStats,
+		AppLoading,
+		AppSlider,
 		AppSticker,
 	},
 })
@@ -36,11 +41,11 @@ export default class AppFiresideStream extends Vue {
 	@Prop({ type: FiresideRTCUser, required: true })
 	rtcUser!: FiresideRTCUser;
 
-	@Prop({ type: Boolean, required: false, default: false })
-	showOverlayHosts!: boolean;
+	@Prop({ type: Boolean, default: false })
+	hasHeader!: boolean;
 
-	@Prop({ type: ChatUserCollection, required: false, default: null })
-	members!: ChatUserCollection | null;
+	@Prop({ type: Boolean, default: false })
+	hasHosts!: boolean;
 
 	@InjectReactive(FiresideControllerKey) c!: FiresideController;
 	@Inject(DrawerStoreKey) drawerStore!: DrawerStore;
@@ -64,6 +69,14 @@ export default class AppFiresideStream extends Vue {
 		return fuzzynumber(this.stickerStreak?.count ?? 0);
 	}
 
+	get desktopVolume() {
+		return this.c.rtc?.desktopVolume ?? 1;
+	}
+
+	get hasVolumeControls() {
+		return !!this.c.rtc?.shouldShowVolumeControls;
+	}
+
 	get shouldShowUI() {
 		if (GJ_IS_SSR) {
 			return false;
@@ -84,15 +97,15 @@ export default class AppFiresideStream extends Vue {
 	}
 
 	get hasOverlayItems() {
-		return this.showOverlayHosts || !!this.members;
+		return this.hasVolumeControls || this.hasHeader;
 	}
 
 	get memberCount() {
-		return this.members?.count;
+		return this.c.chatUsers?.count ?? 1;
 	}
 
 	get videoPaused() {
-		return this.c.rtc?.videoPaused;
+		return this.c.rtc?.videoPaused === true;
 	}
 
 	get hasVideo() {
@@ -111,10 +124,6 @@ export default class AppFiresideStream extends Vue {
 		);
 	}
 
-	get shouldShowOverlayPlayback() {
-		return this.hasVideo;
-	}
-
 	onMouseOut() {
 		this.scheduleUIHide(UIHideTimeout);
 	}
@@ -128,7 +137,7 @@ export default class AppFiresideStream extends Vue {
 
 		// Don't alter video playback here when we have overlays to use tap
 		// interactions with.
-		if (this.hasOverlayItems) {
+		if (!this.videoPaused) {
 			return;
 		}
 
@@ -155,6 +164,10 @@ export default class AppFiresideStream extends Vue {
 
 	onHostOptionsHide() {
 		this.c.isShowingOverlayPopper = false;
+	}
+
+	onVolumeScrub({ percent }: ScrubberCallback) {
+		setRTCDesktopVolume(this.c.rtc!, percent);
 	}
 
 	private animateStickerStreak() {

--- a/src/app/views/fireside/_stream/stream.ts
+++ b/src/app/views/fireside/_stream/stream.ts
@@ -101,7 +101,7 @@ export default class AppFiresideStream extends Vue {
 	}
 
 	get hasOverlayItems() {
-		return this.hasVolumeControls || this.hasHeader;
+		return this.hasVideo || this.hasVolumeControls || this.hasHeader;
 	}
 
 	get memberCount() {

--- a/src/app/views/fireside/_stream/stream.vue
+++ b/src/app/views/fireside/_stream/stream.vue
@@ -11,11 +11,9 @@
 		<template v-if="hasVideo">
 			<template v-if="videoPaused">
 				<transition>
-					<template v-if="!hasOverlayItems">
-						<div class="-paused-indicator -click-target anim-fade-leave-shrink">
-							<app-jolticon class="-paused-indicator-icon" icon="play" />
-						</div>
-					</template>
+					<div class="-paused-indicator -click-target anim-fade-leave-shrink">
+						<app-jolticon class="-paused-indicator-icon" icon="play" />
+					</div>
 				</transition>
 			</template>
 			<template v-else-if="isLoadingVideo">
@@ -54,36 +52,51 @@
 		>
 			<template v-if="shouldShowUI">
 				<div class="-overlay-inner">
-					<div v-if="memberCount" class="-overlay-members">
-						<translate
-							:translate-n="memberCount"
-							:translate-params="{ count: number(memberCount) }"
-							translate-plural="%{ count } members"
-						>
-							%{ count } member
-						</translate>
-					</div>
-
-					<div class="-overlay-playback">
-						<div
-							v-if="shouldShowOverlayPlayback"
-							class="-overlay-playback-inner"
-							@click="togglePlayback"
-						>
-							<app-jolticon
-								class="-paused-indicator-icon"
-								:icon="videoPaused ? 'play' : 'pause'"
-							/>
+					<div class="-overlay-top -control">
+						<div v-if="hasHeader" style="flex: auto; overflow: hidden">
+							<app-fireside-header is-overlay />
+							<div class="-overlay-members">
+								<translate
+									:translate-n="memberCount"
+									:translate-params="{ count: number(memberCount) }"
+									translate-plural="%{ count } members"
+								>
+									%{ count } member
+								</translate>
+							</div>
 						</div>
 					</div>
 
-					<div v-if="showOverlayHosts" class="-overlay-hosts -control">
-						<app-fireside-host-list
-							hide-thumb-options
-							@show-popper="onHostOptionsShow"
-							@hide-popper="onHostOptionsHide"
-						/>
+					<div class="-overlay-bottom -control">
+						<div class="-video-controls">
+							<div v-if="hasVideo">
+								<app-button
+									circle
+									trans
+									overlay
+									:icon="videoPaused ? 'play' : 'pause'"
+									@click.capture.stop="togglePlayback"
+								/>
+							</div>
+
+							<div v-if="hasVolumeControls" class="-volume">
+								<app-jolticon icon="audio" />
+								<app-slider
+									class="-volume-slider"
+									:percent="desktopVolume"
+									@scrub="onVolumeScrub"
+								/>
+							</div>
+						</div>
 					</div>
+
+					<app-fireside-host-list
+						v-if="hasHosts"
+						class="-hosts"
+						hide-thumb-options
+						@show-popper="onHostOptionsShow"
+						@hide-popper="onHostOptionsHide"
+					/>
 				</div>
 			</template>
 		</div>
@@ -120,6 +133,14 @@
 @import '~styles/variables'
 @import '~styles-lib/mixins'
 
+$-text-shadow = 1px 1px 3px rgba($black, 0.5)
+$-z-overlay = 1
+$-z-combo = 2
+$-z-paused = 2
+
+.jolticon
+	text-shadow: $-text-shadow
+
 .-stream
 .-video-player
 	&
@@ -130,10 +151,10 @@
 		bottom: 0
 		left: 0
 		color: var(--theme-fg)
-		text-shadow: 1px 1px 3px rgba($black, 0.5)
+		text-shadow: $-text-shadow
 
 	> .-overlay
-		z-index: 1
+		z-index: $-z-overlay
 		opacity: 0
 		transition: all 200ms $strong-ease-out
 
@@ -149,10 +170,7 @@
 	width: 100%
 	display: flex
 	flex-direction: column
-	padding: 8px 0
-
-	> *
-		flex: 1
+	padding: 8px
 
 .-visible-center
 	opacity: 1 !important
@@ -173,21 +191,15 @@
 	left: 0
 
 .-overlay-members
-	padding: 0 8px
+	opacity: 0.75
 	font-weight: bold
 
-.-overlay-playback
-	flex: auto
+.-overlay-top
 	display: flex
-	align-items: center
-	justify-content: center
-	min-height: 0
+	align-items: flex-start
+	margin-bottom: auto
 
-	&-inner
-		padding: 16px
-		margin: -(@padding)
-
-.-overlay-hosts
+.-overlay-bottom
 	display: flex
 	align-items: flex-end
 
@@ -205,9 +217,29 @@
 	display: flex
 	align-items: center
 	justify-content: center
+	z-index: $-z-paused
+	pointer-events: none
 
 	&-icon
 		font-size: 60px
+
+.-video-controls
+	display: flex
+	align-items: center
+	flex: 1
+	grid-gap: 12px
+
+	.-volume
+		display: inline-flex
+		align-items: center
+		flex: auto
+		grid-gap: 4px
+
+		&-slider
+			max-width: 200px
+
+.-hosts
+	margin-top: 8px
 
 .-combo
 	position: absolute
@@ -218,7 +250,7 @@
 	font-weight: bold
 	color: white
 	align-items: center
-	z-index: 2
+	z-index: $-z-combo
 	transition: opacity 200ms $strong-ease-out
 
 	&.-fade

--- a/src/app/views/fireside/_stream/stream.vue
+++ b/src/app/views/fireside/_stream/stream.vue
@@ -9,14 +9,7 @@
 		@click="onVideoClick"
 	>
 		<template v-if="hasVideo">
-			<template v-if="videoPaused">
-				<transition>
-					<div class="-paused-indicator -click-target anim-fade-leave-shrink">
-						<app-jolticon class="-paused-indicator-icon" icon="play" />
-					</div>
-				</transition>
-			</template>
-			<template v-else-if="isLoadingVideo">
+			<template v-if="isLoadingVideo">
 				<div class="-overlay -visible-center">
 					<app-loading centered stationary no-color hide-label />
 				</div>
@@ -51,9 +44,20 @@
 			@click.capture="onOverlayTap"
 		>
 			<template v-if="shouldShowUI">
+				<template v-if="videoPaused">
+					<transition>
+						<div
+							ref="paused"
+							class="-paused-indicator -click-target anim-fade-leave-shrink"
+						>
+							<app-jolticon class="-paused-indicator-icon" icon="play" />
+						</div>
+					</transition>
+				</template>
+
 				<div class="-overlay-inner">
-					<div class="-overlay-top -control">
-						<div v-if="hasHeader" style="flex: auto; overflow: hidden">
+					<div v-if="hasHeader" class="-overlay-top -control">
+						<div style="flex: auto; overflow: hidden">
 							<app-fireside-header is-overlay />
 							<div class="-overlay-members">
 								<translate
@@ -67,7 +71,9 @@
 						</div>
 					</div>
 
-					<div class="-overlay-bottom -control">
+					<div class="-flex-spacer" />
+
+					<div class="-overlay-bottom -control" @click.stop>
 						<div class="-video-controls">
 							<div v-if="hasVideo">
 								<app-button
@@ -135,8 +141,8 @@
 
 $-text-shadow = 1px 1px 3px rgba($black, 0.5)
 $-z-overlay = 1
+$-z-control = 3
 $-z-combo = 2
-$-z-paused = 2
 
 .jolticon
 	text-shadow: $-text-shadow
@@ -172,6 +178,9 @@ $-z-paused = 2
 	flex-direction: column
 	padding: 8px
 
+	> *
+		z-index: $-z-control
+
 .-visible-center
 	opacity: 1 !important
 	display: flex
@@ -197,16 +206,20 @@ $-z-paused = 2
 .-overlay-top
 	display: flex
 	align-items: flex-start
-	margin-bottom: auto
 
 .-overlay-bottom
 	display: flex
 	align-items: flex-end
+	width: min-content
 
 .-control
 	&
 	>>>
 		user-select: none
+
+.-flex-spacer
+	margin: auto
+	pointer-events: none
 
 .-paused-indicator
 	position: absolute
@@ -217,11 +230,10 @@ $-z-paused = 2
 	display: flex
 	align-items: center
 	justify-content: center
-	z-index: $-z-paused
-	pointer-events: none
 
 	&-icon
 		font-size: 60px
+		pointer-events: none
 
 .-video-controls
 	display: flex

--- a/src/app/views/fireside/fireside.ts
+++ b/src/app/views/fireside/fireside.ts
@@ -17,6 +17,7 @@ import AppLoading from '../../../_common/loading/loading.vue';
 import { Meta } from '../../../_common/meta/meta-service';
 import { Navigate } from '../../../_common/navigate/navigate.service';
 import { AppObserveDimensions } from '../../../_common/observe-dimensions/observe-dimensions.directive';
+import { Popper } from '../../../_common/popper/popper.service';
 import AppPopper from '../../../_common/popper/popper.vue';
 import { AppResponsiveDimensions } from '../../../_common/responsive-dimensions/responsive-dimensions';
 import { BaseRouteComponent, RouteResolver } from '../../../_common/route/route-component';
@@ -268,6 +269,7 @@ export default class RouteFireside extends BaseRouteComponent {
 	toggleVideoStats() {
 		if (this.c) {
 			toggleStreamVideoStats(this.c);
+			Popper.hideAll();
 		}
 	}
 

--- a/src/app/views/fireside/fireside.ts
+++ b/src/app/views/fireside/fireside.ts
@@ -101,6 +101,7 @@ export default class RouteFireside extends BaseRouteComponent {
 	c: FiresideController | null = null;
 
 	private beforeEachDeregister: Function | null = null;
+	private canShowMobileHosts = true;
 
 	readonly Screen = Screen;
 	readonly number = number;
@@ -174,11 +175,15 @@ export default class RouteFireside extends BaseRouteComponent {
 	}
 
 	get shouldShowChatMemberStats() {
-		return this.shouldShowHosts && !!this.c?.isStreaming;
+		return this.shouldShowDesktopHosts && !!this.c?.isStreaming;
 	}
 
-	get shouldShowHosts() {
+	get shouldShowDesktopHosts() {
 		return !this.isVertical && !Screen.isMobile;
+	}
+
+	get shouldShowMobileHosts() {
+		return this.canShowMobileHosts && !!this.c?.isStreaming;
 	}
 
 	get shouldShowReactions() {
@@ -281,6 +286,10 @@ export default class RouteFireside extends BaseRouteComponent {
 		if (url) {
 			Navigate.newWindow(url);
 		}
+	}
+
+	onChatEditorFocusChange(isFocused: boolean) {
+		this.canShowMobileHosts = !isFocused;
 	}
 
 	@Watch('c.isPersonallyStreaming')

--- a/src/app/views/fireside/fireside.ts
+++ b/src/app/views/fireside/fireside.ts
@@ -153,13 +153,6 @@ export default class RouteFireside extends BaseRouteComponent {
 		return this.chat.messageQueue.filter(i => i.room_id === this.c?.chatRoom?.id);
 	}
 
-	get overlayChatMembers() {
-		if (this.shouldShowHosts) {
-			return;
-		}
-		return this.c?.chatUsers;
-	}
-
 	get shouldFullscreenStream() {
 		if (!this.c?.isStreaming) {
 			return false;

--- a/src/app/views/fireside/fireside.vue
+++ b/src/app/views/fireside/fireside.vue
@@ -8,7 +8,6 @@
 			<app-fireside-header
 				class="-header"
 				:show-controls="shouldShowTitleControls"
-				:has-info="!shouldShowFiresideStats"
 				:has-chat="!shouldShowChatMembers"
 				:has-chat-stats="shouldShowChatMemberStats"
 			/>
@@ -77,8 +76,10 @@
 									<app-popper trigger="right-click">
 										<app-fireside-stream
 											:rtc-user="c.rtc.focusedUser"
-											:show-overlay-hosts="!shouldShowHosts"
-											:members="overlayChatMembers"
+											:has-header="
+												shouldShowHeaderInBody || shouldFullscreenStream
+											"
+											:has-hosts="shouldFullscreenStream"
 										/>
 
 										<template #popover>
@@ -231,14 +232,11 @@
 					<app-sticker-reactions :controller="c.stickerTargetController" />
 				</app-fade-collapse>
 
-				<app-expand v-if="shouldShowHeaderInBody" :when="c.isShowingStreamOverlay">
-					<app-fireside-header
-						class="-header"
-						has-overlay-popovers
-						:show-controls="shouldShowTitleControls"
-						:has-chat="!shouldShowChatMembers"
-						:has-chat-stats="shouldShowChatMemberStats"
-					/>
+				<!-- TODO: Hook into the ContentEditorController so we can hide only when editing a message -->
+				<app-expand v-if="!shouldShowHosts" :when="c.isShowingStreamOverlay">
+					<div class="-mobile-hosts">
+						<app-fireside-host-list />
+					</div>
 				</app-expand>
 
 				<div v-if="c.status === 'joined'" class="-chat-wrapper">
@@ -481,6 +479,13 @@
 	.-video-wrapper.-vertical &
 		padding-top: 0
 		padding-right: 8px
+
+.-mobile-hosts
+	// TODO: Get the host list to pad itself - seems to be overflowing active indicator currently.
+	padding-top: 6px
+	padding-bottom: 20px
+	display: flex
+	justify-content: center
 
 .-chat-wrapper
 	position: relative

--- a/src/app/views/fireside/fireside.vue
+++ b/src/app/views/fireside/fireside.vue
@@ -58,7 +58,7 @@
 							>
 								<template v-if="GJ_IS_CLIENT">
 									<app-illustration
-										v-if="shouldShowHosts && shortestSide > 700"
+										v-if="shouldShowDesktopHosts && shortestSide > 700"
 										src="~img/ill/no-comments.svg"
 									/>
 
@@ -99,7 +99,7 @@
 					</div>
 				</div>
 
-				<div v-if="c.rtc && shouldShowHosts" class="-hosts-padding">
+				<div v-if="c.rtc && shouldShowDesktopHosts" class="-hosts-padding">
 					<div class="-hosts">
 						<app-fireside-host-list />
 					</div>
@@ -232,10 +232,9 @@
 					<app-sticker-reactions :controller="c.stickerTargetController" />
 				</app-fade-collapse>
 
-				<!-- TODO: Hook into the ContentEditorController so we can hide only when editing a message -->
-				<app-expand v-if="!shouldShowHosts" :when="c.isShowingStreamOverlay">
+				<app-expand v-if="!shouldShowDesktopHosts" :when="shouldShowMobileHosts">
 					<div class="-mobile-hosts">
-						<app-fireside-host-list />
+						<app-fireside-host-list hide-thumb-options />
 					</div>
 				</app-expand>
 
@@ -263,6 +262,7 @@
 							v-else-if="chat && chat.currentUser"
 							class="-chat-window-input"
 							:room="c.chatRoom"
+							@focus-change="onChatEditorFocusChange"
 						/>
 					</div>
 				</div>
@@ -481,7 +481,6 @@
 		padding-right: 8px
 
 .-mobile-hosts
-	// TODO: Get the host list to pad itself - seems to be overflowing active indicator currently.
 	padding-top: 6px
 	padding-bottom: 20px
 	display: flex

--- a/src/app/views/fireside/fireside.vue
+++ b/src/app/views/fireside/fireside.vue
@@ -37,51 +37,64 @@
 						v-app-observe-dimensions="onDimensionsChange"
 						class="-video-container"
 					>
-						<app-sticker-target
-							:controller="c.stickerTargetController"
+						<div
 							class="-video-inner"
-							:class="{
-								'-unsupported': GJ_IS_CLIENT,
-							}"
 							:style="{
 								width: videoWidth + 'px',
 								height: videoHeight + 'px',
 							}"
 						>
-							<template v-if="GJ_IS_CLIENT">
-								<app-illustration
-									v-if="shouldShowHosts && shortestSide > 700"
-									src="~img/ill/no-comments.svg"
-								/>
-
-								<p class="-unsupported-text">
-									<translate>
-										Oh no... Fireside streams don't work on the Client yet.
-									</translate>
-								</p>
-
-								<app-button @click="onClickOpenBrowser()">
-									<translate>Open Fireside in Browser</translate>
-								</app-button>
-							</template>
-							<template v-else-if="c.rtc && c.rtc.focusedUser">
-								<app-popper trigger="right-click">
-									<app-fireside-stream
-										:rtc-user="c.rtc.focusedUser"
-										:show-overlay-hosts="!shouldShowHosts"
-										:members="overlayChatMembers"
+							<app-sticker-target
+								class="-video-inner"
+								:controller="c.stickerTargetController"
+								:class="{
+									'-unsupported': GJ_IS_CLIENT,
+								}"
+								:style="{
+									top: 0,
+									right: 0,
+									bottom: 0,
+									left: 0,
+								}"
+							>
+								<template v-if="GJ_IS_CLIENT">
+									<app-illustration
+										v-if="shouldShowHosts && shortestSide > 700"
+										src="~img/ill/no-comments.svg"
 									/>
 
-									<template #popover>
-										<div class="list-group">
-											<a class="list-group-item" @click="toggleVideoStats()">
-												<translate>Toggle Video Stats</translate>
-											</a>
-										</div>
-									</template>
-								</app-popper>
-							</template>
-						</app-sticker-target>
+									<p class="-unsupported-text">
+										<translate>
+											Oh no... Fireside streams don't work on the Client yet.
+										</translate>
+									</p>
+
+									<app-button @click="onClickOpenBrowser()">
+										<translate>Open Fireside in Browser</translate>
+									</app-button>
+								</template>
+								<template v-else-if="c.rtc && c.rtc.focusedUser">
+									<app-popper trigger="right-click">
+										<app-fireside-stream
+											:rtc-user="c.rtc.focusedUser"
+											:show-overlay-hosts="!shouldShowHosts"
+											:members="overlayChatMembers"
+										/>
+
+										<template #popover>
+											<div class="list-group">
+												<a
+													class="list-group-item"
+													@click="toggleVideoStats()"
+												>
+													<translate>Toggle Video Stats</translate>
+												</a>
+											</div>
+										</template>
+									</app-popper>
+								</template>
+							</app-sticker-target>
+						</div>
 					</div>
 				</div>
 


### PR DESCRIPTION
- Shows host list below video when desktop or portrait mobile, hiding when editing chat for mobile
- Move the fireside header into the overlay for mobile
- Move the desktop audio slider into the overlay
- Display a thumbnail of the latest video data when pausing the stream