### PR TITLE
Fix touch scrolling oddities when scrolling every other time on swipe-able media

### DIFF
--- a/src/_common/audio/scrubber/scrubber.vue
+++ b/src/_common/audio/scrubber/scrubber.vue
@@ -10,6 +10,7 @@
 		@panend="panEnd"
 		@tap="tap"
 		@touchmove.native="onTouchMove"
+		@touchend.native="isDragging = false"
 	>
 		<div ref="timebar" class="audio-scrubber-timebar">
 			<div class="audio-scrubber-timebar-handle" :style="{ right: unfilledRight }" />

--- a/src/_common/video/player/scrubber/scrubber.vue
+++ b/src/_common/video/player/scrubber/scrubber.vue
@@ -9,6 +9,7 @@
 		@panend="panEnd"
 		@tap="tap"
 		@touchmove.native="onTouchMove"
+		@touchend.native="isDragging = false"
 		@click.native.capture.prevent
 	>
 		<div ref="timebar" class="-timebar" :class="{ '-dragging': player.isScrubbing }">

--- a/src/app/components/activity/feed/post/media/media.vue
+++ b/src/app/components/activity/feed/post/media/media.vue
@@ -9,6 +9,7 @@
 			@panmove="pan"
 			@panend="panEnd"
 			@touchmove.native="onTouchMove"
+			@touchend.native="isDragging = false"
 		>
 			<div class="-container">
 				<div ref="slider" class="-slider">


### PR DESCRIPTION
Unsets the isDragging field so we don't prevent the default scroll behavior when scrolling the second time on top of swipe-able media.