### PR TITLE
Fix stream previews showing only a black background

### DIFF
--- a/src/app/components/fireside/stream/AppFiresideStreamVideo.vue
+++ b/src/app/components/fireside/stream/AppFiresideStreamVideo.vue
@@ -106,14 +106,14 @@ function _onShouldPlayVideoChange() {
 </script>
 
 <template>
-	<div class="-video-player">
+	<div class="-stream-video">
 		<div ref="videoElem" />
 		<canvas v-show="!shouldPlayVideo" ref="canvasElem" />
 	</div>
 </template>
 
 <style lang="stylus" scoped>
-.-video-player
+.-stream-video
 	position: relative
 
 	&

--- a/src/app/components/fireside/stream/preview/AppFiresideStreamPreviewVideo.vue
+++ b/src/app/components/fireside/stream/preview/AppFiresideStreamPreviewVideo.vue
@@ -73,9 +73,9 @@ onBeforeUnmount(() => cleanupController());
 </script>
 
 <template>
-	<AppFiresideContainer class="-stream theme-dark" :controller="c">
+	<AppFiresideContainer class="-stream-preview-video theme-dark" :controller="c">
 		<div v-if="focusedUser && shouldShowVideo" :key="focusedUser.uid">
-			<AppFiresideStreamVideo class="-video-player" :rtc-user="focusedUser" />
+			<AppFiresideStreamVideo class="-stream-preview-video-inner" :rtc-user="focusedUser" />
 
 			<div class="-overlay">
 				<div v-if="showLive" class="-center">
@@ -93,10 +93,10 @@ onBeforeUnmount(() => cleanupController());
 </template>
 
 <style lang="stylus" scoped>
-.-stream
-.-video-player
+.-stream-preview-video
+.-stream-preview-video-inner
 .-overlay
-	position: absolute
+	position: absolute !important
 	top: 0
 	right: 0
 	bottom: 0


### PR DESCRIPTION
A class name duplication was overwriting `position: absolute` from the parent styling