### PR TITLE
Fix email auth tracking login instead of join

### DIFF
--- a/src/auth/views/auth/authorize/authorize.vue
+++ b/src/auth/views/auth/authorize/authorize.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Options } from 'vue-property-decorator';
 import { Api } from '../../../../_common/api/api.service';
-import { authOnLogin, redirectToOnboarding } from '../../../../_common/auth/auth.service';
+import { authOnJoin, redirectToOnboarding } from '../../../../_common/auth/auth.service';
 import { BaseRouteComponent, OptionsForRoute } from '../../../../_common/route/route-component';
 
 @Options({
@@ -34,7 +34,7 @@ export default class RouteAuthAuthorize extends BaseRouteComponent {
 
 		// Redirect them to onboarding.
 		if (this.isSuccess) {
-			authOnLogin('email');
+			authOnJoin('email');
 			redirectToOnboarding();
 		}
 	}

--- a/src/auth/views/auth/join-almost/join-almost.vue
+++ b/src/auth/views/auth/join-almost/join-almost.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Options } from 'vue-property-decorator';
 import { Api } from '../../../../_common/api/api.service';
-import { authOnLogin, redirectToOnboarding } from '../../../../_common/auth/auth.service';
+import { authOnJoin, redirectToOnboarding } from '../../../../_common/auth/auth.service';
 import { showErrorGrowl } from '../../../../_common/growls/growls.service';
 import AppLoading from '../../../../_common/loading/AppLoading.vue';
 import { AppProgressPoller } from '../../../../_common/progress/poller/poller';
@@ -54,8 +54,8 @@ export default class RouteJoinAlmost extends BaseRouteComponent {
 			return;
 		}
 
-		// If it worked, redirect to onbaording flow. They're good to go!
-		authOnLogin('email');
+		// If it worked, redirect to onboarding flow. They're good to go!
+		authOnJoin('email');
 		redirectToOnboarding();
 	}
 }


### PR DESCRIPTION
This ended up breaking our config service conditions as well, causing email-authed joins to be marked as `excluded` for tests they should have been part of.