### PR TITLE
Fireside only owner publish

### DIFF
--- a/src/_common/collaborator/collaboratable.ts
+++ b/src/_common/collaborator/collaboratable.ts
@@ -27,7 +27,8 @@ export type Perm =
 	| 'fireside-collaborators'
 	| 'fireside-edit'
 	| 'fireside-extend'
-	| 'fireside-extinguish';
+	| 'fireside-extinguish'
+	| 'fireside-publish';
 
 export const Collaboratable = <T extends new (...args: any[]) => Model>(Base: T) =>
 	class extends Base {

--- a/src/app/components/fireside/controller/controller.ts
+++ b/src/app/components/fireside/controller/controller.ts
@@ -301,12 +301,7 @@ export function createFiresideController(
 	const canEdit = computed(() => isOwner.value || fireside.hasPerms('fireside-edit'));
 
 	const canPublish = computed(() => {
-		const role = fireside.role?.role;
-		if (isOwner.value || role === 'host') {
-			return status.value === 'joined' && isDraft.value;
-		}
-
-		return false;
+		return status.value === 'joined' && isDraft.value && fireside.hasPerms('fireside-publish');
 	});
 
 	const _canExtend = computed(() => {


### PR DESCRIPTION
Backend returns a new perm called `fireside-publish` that is required to publish a Fireside, vs currently it checks for the owner of the Fireside.
This will effectly not change anything, because that perm is only granted to the owner.