### PR TITLE
Fix analytics paths for home realm feeds, remove Fireside auto-refresh

### DIFF
--- a/src/_common/analytics/analytics.service.ts
+++ b/src/_common/analytics/analytics.service.ts
@@ -139,19 +139,30 @@ export function initAnalyticsRouter(router: Router) {
 		next();
 	});
 
-	onRouteChangeAfter.subscribe(() => {
-		const route = router.currentRoute.value;
-		const analyticsPath = route.meta.analyticsPath as string | undefined;
+	onRouteChangeAfter.subscribe(() => trackPageViewAfterRoute(router));
+}
 
-		// Track the page view using the analyticsPath if we have one
-		// assigned to the route meta.
-		if (analyticsPath) {
-			_trackPageview(analyticsPath);
-			return;
-		}
+/**
+ * Tracks the page view for the current route.
+ *
+ * If there's an `analyticsPath` assigned to the route meta, we'll use that
+ * instead.
+ *
+ * NOTE: This is typically called automatically by the router, but may need to
+ * be called manually for certain routes that don't trigger a full route change.
+ */
+export function trackPageViewAfterRoute(router: Router) {
+	const route = router.currentRoute.value;
+	const analyticsPath = route.meta.analyticsPath as string | undefined;
 
-		_trackPageview(route.fullPath);
-	});
+	// Track the page view using the analyticsPath if we have one assigned to
+	// the route meta.
+	if (analyticsPath) {
+		_trackPageview(analyticsPath);
+		return;
+	}
+
+	_trackPageview(route.fullPath);
 }
 
 function _trackPageview(path?: string) {

--- a/src/app/components/fireside/avatar/AppFiresideAvatarAdd.vue
+++ b/src/app/components/fireside/avatar/AppFiresideAvatarAdd.vue
@@ -13,10 +13,16 @@ import { FiresideAddModal } from '../add-modal/add-modal.service';
 import AppFiresideAvatarBase from './AppFiresideAvatarBase.vue';
 
 const props = defineProps({
+	/**
+	 * Initial community to populate the content targets with.
+	 */
 	community: {
 		type: Object as PropType<Community>,
 		default: undefined,
 	},
+	/**
+	 * Initial realms to populate the content targets with.
+	 */
 	realms: {
 		type: Array as PropType<Realm[]>,
 		default: () => [],

--- a/src/app/components/forms/fireside/AppFormFiresideAdd.vue
+++ b/src/app/components/forms/fireside/AppFormFiresideAdd.vue
@@ -24,8 +24,14 @@ type FormModel = {
 };
 
 const props = defineProps({
-	community: { type: Object as PropType<Community>, default: null },
-	realms: { type: Array as PropType<Realm[]>, default: () => [] },
+	community: {
+		type: Object as PropType<Community>,
+		default: null,
+	},
+	realms: {
+		type: Array as PropType<Realm[]>,
+		default: () => [],
+	},
 	...defineFormProps<FormModel>(false),
 });
 

--- a/src/app/views/discover/home/RouteDiscoverHome.vue
+++ b/src/app/views/discover/home/RouteDiscoverHome.vue
@@ -16,6 +16,7 @@ import { useCommonStore } from '../../../../_common/store/common-store';
 import { $gettext } from '../../../../_common/translate/translate.service';
 import { FeaturedItem } from '../../../components/featured-item/featured-item.model';
 import socialImage from '../../../img/social/social-share-header.png';
+import { updateHomeRouteAnalyticsPath } from '../../home/RouteHome.vue';
 import AppHomeDefault from './AppHomeDefault.vue';
 import AppHomeSlider from './AppHomeSlider.vue';
 
@@ -107,6 +108,8 @@ const { isBootstrapped } = createAppRoute({
 				: [];
 			HistoryCache.store(route, creatorPosts.value, CachedCreatorsKey);
 		}
+
+		updateHomeRouteAnalyticsPath(route, user.value);
 	},
 });
 </script>

--- a/src/app/views/home/RouteHome.vue
+++ b/src/app/views/home/RouteHome.vue
@@ -1,16 +1,15 @@
 <script lang="ts">
 import { defineAsyncComponent } from 'vue';
-import { useRoute } from 'vue-router';
+import { RouteLocationNormalized, useRoute } from 'vue-router';
 import { router } from '..';
-import { trackExperimentEngagement } from '../../../_common/analytics/analytics.service';
 import { Api } from '../../../_common/api/api.service';
-import { configHomeFeedSwitcher } from '../../../_common/config/config.service';
 import {
 	asyncRouteLoader,
 	createAppRoute,
 	defineAppRouteOptions,
 } from '../../../_common/route/route-component';
 import { useCommonStore } from '../../../_common/store/common-store';
+import { User } from '../../../_common/user/user.model';
 import { IntentService } from '../../components/intent/intent.service';
 import { RealmPathHistoryStateKey } from './feed-switcher/AppHomeFeedSwitcher.vue';
 import { HomeFeedService } from './home-feed.service';
@@ -21,6 +20,48 @@ const RouteHomeFeed = defineAsyncComponent(() =>
 const RouteDiscoverHome = defineAsyncComponent(() =>
 	asyncRouteLoader(router, import('../discover/home/RouteDiscoverHome.vue'))
 );
+
+/**
+ * Returns the current analytics path we have assigned.
+ */
+export function getCurrentHomeRouteAnalyticsPath(route: RouteLocationNormalized) {
+	const path = route.meta.analyticsPath;
+	if (path && typeof path === 'string') {
+		return path;
+	}
+	return undefined;
+}
+
+/**
+ * Returns the analytics path we should assign to the route.
+ */
+export function getNewHomeRouteAnalyticsPath(route: RouteLocationNormalized, user: User | null) {
+	// The route content, but not the path, changes depending on the user state
+	// - so we need to track the page view through a analyticsPath meta value
+	// that aligns with our route content.
+	let analyticsPath = '/discover';
+	if (user) {
+		const tab = route.params?.tab;
+		if (tab === HomeFeedService.fypTab) {
+			analyticsPath = '/fyp';
+		} else if (tab === HomeFeedService.activityTab) {
+			analyticsPath = '/'; // For clarification purposes that "activity" => "/".
+		} else {
+			const realmPath = router.options.history.state[RealmPathHistoryStateKey];
+
+			if (typeof realmPath === 'string' && realmPath.length) {
+				analyticsPath = `/realm-${realmPath}`;
+			} else {
+				analyticsPath = '/';
+			}
+		}
+	}
+	return analyticsPath;
+}
+
+export function updateHomeRouteAnalyticsPath(route: RouteLocationNormalized, user: User | null) {
+	route.meta.analyticsPath = getNewHomeRouteAnalyticsPath(route, user);
+}
 
 export default {
 	...defineAppRouteOptions({
@@ -45,30 +86,7 @@ const route = useRoute();
 createAppRoute({
 	routeTitle: null,
 	onResolved() {
-		trackExperimentEngagement(configHomeFeedSwitcher);
-
-		// The route content, but not the path, changes depending on the user
-		// state - so we need to track the page view through a analyticsPath
-		// meta value that aligns with our route content.
-		let analyticsPath = '/discover';
-		if (user.value) {
-			const tab = route.params?.tab;
-			if (tab === HomeFeedService.fypTab) {
-				analyticsPath = '/fyp';
-			} else if (tab === HomeFeedService.activityTab) {
-				analyticsPath = '/'; // For clarification purposes that "activity" => "/".
-			} else {
-				const realmPath = router.options.history.state[RealmPathHistoryStateKey];
-
-				if (typeof realmPath === 'string' && realmPath.length) {
-					analyticsPath = `/realm-${realmPath}`;
-				} else {
-					analyticsPath = '/';
-				}
-			}
-		}
-
-		route.meta.analyticsPath = analyticsPath;
+		updateHomeRouteAnalyticsPath(route, user.value);
 	},
 });
 </script>

--- a/src/app/views/home/_fireside/AppHomeFireside.vue
+++ b/src/app/views/home/_fireside/AppHomeFireside.vue
@@ -55,9 +55,12 @@ const gridStyling = computed(() => ({
 }));
 
 function onFiresideExpired() {
-	// When a fireside expired while showing it here, refresh the list.
-	// It will be excluded from the next fetch.
-	emit('request-refresh');
+	// When a fireside expired while showing it here, refresh the list. It will
+	// be excluded from the next fetch.
+	//
+	// TODO: Do this in a more efficient way. Can't be sending automatic polling
+	// requests when we're having firesides that are persistent.
+	// emit('request-refresh');
 }
 </script>
 

--- a/src/app/views/home/_fireside/AppHomeFireside.vue
+++ b/src/app/views/home/_fireside/AppHomeFireside.vue
@@ -2,6 +2,7 @@
 import { computed, PropType } from 'vue';
 import { Fireside } from '../../../../_common/fireside/fireside.model';
 import AppLoadingFade from '../../../../_common/loading/AppLoadingFade.vue';
+import { Realm } from '../../../../_common/realm/realm-model';
 import { Screen } from '../../../../_common/screen/screen-service';
 import AppScrollScroller from '../../../../_common/scroll/AppScrollScroller.vue';
 import AppTranslate from '../../../../_common/translate/AppTranslate.vue';
@@ -29,6 +30,10 @@ const props = defineProps({
 	},
 	showPlaceholders: {
 		type: Boolean,
+	},
+	initialRealm: {
+		type: Object as PropType<Realm>,
+		default: undefined,
 	},
 });
 
@@ -96,7 +101,11 @@ function onFiresideExpired() {
 						<AppFiresideAvatarBase v-for="i of gridColumns" :key="i" is-placeholder />
 					</div>
 					<div v-else key="list" :style="gridStyling">
-						<AppFiresideAvatarAdd v-if="!userFireside" key="add" />
+						<AppFiresideAvatarAdd
+							v-if="!userFireside"
+							key="add"
+							:realms="initialRealm ? [initialRealm] : undefined"
+						/>
 						<AppFiresideAvatar
 							v-for="fireside of displayFiresides"
 							:key="fireside.id"


### PR DESCRIPTION
Also initializes the fireside creation form with the realm we're viewing on the home feed.