### PR TITLE
Fix fireside backgrounds flickering when hosts update

### DIFF
--- a/src/_common/background/AppBackground.vue
+++ b/src/_common/background/AppBackground.vue
@@ -147,9 +147,9 @@ if (import.meta.env.SSR) {
 	bottom: 0
 
 .-scroll
-		animation-timing-function: linear !important
-		animation-duration: 20s
-		animation-iteration-count: infinite
+	animation-timing-function: linear !important
+	animation-duration: 20s
+	animation-iteration-count: infinite
 
 .-scroll-left
 .-scroll-right

--- a/src/_common/fireside/rtc/rtc.ts
+++ b/src/_common/fireside/rtc/rtc.ts
@@ -1,6 +1,6 @@
 import type { IAgoraRTC, IAgoraRTCRemoteUser } from 'agora-rtc-sdk-ng';
 import { markRaw, reactive, Ref } from 'vue';
-import { arrayAssignAll, arrayRemove } from '../../../utils/array';
+import { arrayRemove } from '../../../utils/array';
 import { CancelToken } from '../../../utils/cancel-token';
 import { debounce, sleep } from '../../../utils/utils';
 import { Background } from '../../background/background.model';
@@ -263,10 +263,6 @@ async function _recreateFiresideRTC(rtc: FiresideRTC) {
 	rtc.log('Trace(recreate)');
 	await destroyFiresideRTC(rtc);
 	return _setup(rtc);
-}
-
-export function setHosts(rtc: FiresideRTC, newHosts: FiresideRTCHost[]) {
-	arrayAssignAll(rtc.hosts, newHosts);
 }
 
 export function setListableHostIds(rtc: FiresideRTC, listableHostIds: Set<number>) {

--- a/src/app/components/fireside/controller/controller.ts
+++ b/src/app/components/fireside/controller/controller.ts
@@ -52,7 +52,6 @@ import {
 	destroyFiresideRTC,
 	FiresideRTC,
 	FiresideRTCHost,
-	setHosts,
 	setListableHostIds,
 } from '../../../../_common/fireside/rtc/rtc';
 import { showInfoGrowl, showSuccessGrowl } from '../../../../_common/growls/growls.service';
@@ -149,6 +148,41 @@ export function createFiresideController(
 	 * The hosts that are allowed to stream in the fireside.
 	 */
 	const hosts = ref([]) as Ref<FiresideRTCHost[]>;
+
+	/**
+	 * Performs actions on the new lists of hosts before assigning them to our
+	 * existing list.
+	 *
+	 * - Assigns cached following state for User models.
+	 * - Merges existing streaming uids with new ones.
+	 */
+	function upsertHosts(newHosts: FiresideRTCHost[]) {
+		logger.info('updating hosts in controller');
+
+		// We want to merge the streaming uids of our existing hosts with the new ones.
+		// Note: I'm not 100% sure why we want that. My guess is because we freeze the
+		// streaming uid on the RTCUser instances, but we still want to match against the
+		// same RTCHost with their new streaming uids?
+		for (const newHost of newHosts) {
+			// Assign cached following state.
+			const { is_following, dogtags } = fetchedHostUserData.get(newHost.user.id) || {};
+			newHost.user.is_following = is_following === true;
+			newHost.user.dogtags = dogtags;
+
+			// Merge streaming uids.
+			const prevHost = hosts.value.find(i => i.user.id === newHost.user.id);
+			if (prevHost) {
+				logger.info(`merging streaming uids of host ${newHost.user.id}`);
+
+				// Transfer over all previously assigned uids to the new host.
+				const newUids = arrayUnique([...prevHost.uids, ...newHost.uids]);
+				arrayAssignAll(newHost.uids, newUids);
+			}
+		}
+
+		logger.info('new hosts after merging uids', JSON.stringify(newHosts));
+		arrayAssignAll(hosts.value, newHosts);
+	}
 
 	/**
 	 * Map of userId and data that we specifically requested to supplement
@@ -564,36 +598,6 @@ export function createFiresideController(
 		}
 	});
 
-	const _unwatchHostsChanged = watch(
-		hosts,
-		(newHosts, prevHosts) => {
-			logger.info('updating hosts in controller');
-
-			// We want to merge the streaming uids of our existing hosts with the new ones.
-			// Note: I'm not 100% sure why we want that. My guess is because we freeze the
-			// streaming uid on the RTCUser instances, but we still want to match against the
-			// same RTCHost with their new streaming uids?
-			for (const newHost of newHosts) {
-				const prevHost = prevHosts.find(i => i.user.id === newHost.user.id);
-				if (prevHost) {
-					logger.info(`merging streaming uids of host ${newHost.user.id}`);
-
-					// Transfer over all previously assigned uids to the new host.
-					const newUids = arrayUnique([...prevHost.uids, ...newHost.uids]);
-					arrayAssignAll(newHost.uids, newUids);
-				}
-			}
-
-			logger.info('new hosts after merging uids', JSON.stringify(newHosts));
-
-			if (rtc.value) {
-				logger.info('updating hosts in rtc');
-				setHosts(rtc.value, newHosts);
-			}
-		},
-		{ deep: true }
-	);
-
 	const _unwatchListableHostIdsChanged = watch(
 		listableHostIds,
 		newListableHostIds => {
@@ -765,7 +769,8 @@ export function createFiresideController(
 	const controller = shallowReadonly({
 		fireside,
 		agoraStreamingInfo,
-		hosts,
+		hosts: shallowReadonly(hosts),
+		upsertHosts,
 		fetchedHostUserData,
 		listableHostIds,
 		hostBackgrounds,
@@ -1103,7 +1108,6 @@ export function createFiresideController(
 		_unwatchChatUsers();
 		_unwatchWantsRTC();
 		_unwatchWantsRTCProducer();
-		_unwatchHostsChanged();
 		_unwatchListableHostIdsChanged();
 		_unwatchGridConnection();
 		_unwatchSidebar();
@@ -1239,6 +1243,7 @@ export async function updateFiresideData(
 		user,
 		status,
 		hosts,
+		upsertHosts,
 		chatUsers,
 		chatSettings,
 		rtc,
@@ -1308,10 +1313,7 @@ export async function updateFiresideData(
 		// After updating hosts need to check if we transitioned into or out of
 		// being a host.
 		const wasHost = hosts.value.some(i => i.user.id === user.value?.id);
-		hosts.value = _assignFollowingStateToHosts(
-			c,
-			_getHostsFromStreamingInfo(payload.streamingInfo)
-		);
+		upsertHosts(_getHostsFromStreamingInfo(payload.streamingInfo));
 		chatUsers.value?.assignFiresideHostData(hosts.value);
 		const isHost = hosts.value.some(i => i.user.id === user.value?.id);
 
@@ -1458,7 +1460,17 @@ function isListableHostStreaming(hosts: FiresideRTCHost[], listableHostIds: Set<
  * Returns `false` if there was an error, `true` if not.
  */
 async function _fetchForFiresideStreaming(c: FiresideController, { assignStatus = true }) {
-	const { fireside, status, agoraStreamingInfo, hosts, chatUsers, listableHostIds, logger } = c;
+	const {
+		fireside,
+		status,
+		agoraStreamingInfo,
+		hosts,
+		upsertHosts,
+		chatUsers,
+		listableHostIds,
+		logger,
+	} = c;
+
 	try {
 		const payload = await Api.sendRequest<FullStreamingPayload>(
 			`/web/fireside/fetch-for-streaming/${fireside.hash}`,
@@ -1488,7 +1500,7 @@ async function _fetchForFiresideStreaming(c: FiresideController, { assignStatus 
 		newStreamingInfo.streamingUid = payload.streamingUid;
 		agoraStreamingInfo.value = newStreamingInfo;
 
-		hosts.value = _assignFollowingStateToHosts(c, _getHostsFromStreamingInfo(payload));
+		upsertHosts(_getHostsFromStreamingInfo(payload));
 		chatUsers.value?.assignFiresideHostData(hosts.value);
 
 		listableHostIds.value = new Set(payload.listableHostIds ?? []);
@@ -1535,11 +1547,11 @@ function _getHostsFromStreamingInfo(streamingInfo: StreamingInfoPayload) {
 	const result: FiresideRTCHost[] = [];
 
 	for (const field of ['hosts', 'unlistedHosts'] as const) {
-		const isUnlisted = field === 'unlistedHosts';
 		if (!streamingInfo[field]) {
 			continue;
 		}
 
+		const isUnlisted = field === 'unlistedHosts';
 		const streamingUids = streamingInfo.streamingUids ?? {};
 		const streamingHostIds = streamingInfo.streamingHostIds ?? [];
 		const hostUsers = User.populate(streamingInfo[field] ?? []) as User[];
@@ -1559,17 +1571,4 @@ function _getHostsFromStreamingInfo(streamingInfo: StreamingInfoPayload) {
 	}
 
 	return result;
-}
-
-/**
- * Loops over hosts and sets their `is_following` state to whatever value we've
- * fetched previously.
- */
-function _assignFollowingStateToHosts(c: FiresideController, hosts: FiresideRTCHost[]) {
-	hosts.forEach(i => {
-		const { is_following, dogtags } = c.fetchedHostUserData.get(i.user.id) || {};
-		i.user.is_following = is_following === true;
-		i.user.dogtags = dogtags;
-	});
-	return hosts;
 }


### PR DESCRIPTION
This was happening when new hosts were assigned before merging their existing uids, causing us to briefly lose their User model.