### PR TITLE
Update Notification Text

### DIFF
--- a/src/_common/notification/notification-text.service.ts
+++ b/src/_common/notification/notification-text.service.ts
@@ -1,7 +1,7 @@
 import { Community } from '../community/community.model';
 import {
 	CommunityUserNotification,
-	NotificationType
+	NotificationType,
 } from '../community/user-notification/user-notification.model';
 import { formatCurrency } from '../filters/currency';
 import { FiresideCommunity } from '../fireside/community/community.model';

--- a/src/_common/notification/notification-text.service.ts
+++ b/src/_common/notification/notification-text.service.ts
@@ -504,7 +504,7 @@ export class NotificationText {
 					case 2:
 						return _process(
 							$gettextInterpolate(
-								`<em>%{ user1 }</em> and <em>%{ user2 }</em> are live!.`,
+								`<em>%{ user1 }</em> and <em>%{ user2 }</em> are live!`,
 								userInterpolates,
 								!plaintext
 							)

--- a/src/_common/notification/notification-text.service.ts
+++ b/src/_common/notification/notification-text.service.ts
@@ -1,7 +1,7 @@
 import { Community } from '../community/community.model';
 import {
 	CommunityUserNotification,
-	NotificationType,
+	NotificationType
 } from '../community/user-notification/user-notification.model';
 import { formatCurrency } from '../filters/currency';
 import { FiresideCommunity } from '../fireside/community/community.model';
@@ -467,7 +467,7 @@ export class NotificationText {
 				if (notification.action_model instanceof Fireside) {
 					return _process(
 						$gettextInterpolate(
-							`<em>%{ subject }</em> is live!.`,
+							`<em>%{ subject }</em> is live!`,
 							this.getTranslationValues(notification),
 							!plaintext
 						)


### PR DESCRIPTION
The notification currently shows `User (@user) is live!.`, which has bugged me for some time. Here is a fix to remove the period after the exclamation mark. The notification should now show `User (@user) is live!`