### PR TITLE
Dedupe user Fireside in Realms

### DIFF
--- a/src/app/views/realms/view/overview/RouteRealmsOverview.vue
+++ b/src/app/views/realms/view/overview/RouteRealmsOverview.vue
@@ -49,7 +49,9 @@ const firesidesGridColumns = 5;
 
 const displayablePreviewFiresides = computed(() => {
 	const previewable = userFireside.value
-		? [userFireside.value, ...firesides.value]
+		? // Move the user's Fireside to the start of the list, and remove it from the rest so it
+		  // doesn't show up twice.
+		  [userFireside.value, ...firesides.value.filter(x => x.id !== userFireside.value!.id)]
 		: firesides.value;
 
 	// -1 to leave room for the "add a fireside"


### PR DESCRIPTION
Currently shows up twice if the user's Fireside is also under the first 3 Firesides returned for the Realm.