### PR TITLE
Creator sticker pack disable warning

### DIFF
--- a/src/app/components/forms/sticker/FormSticker.vue
+++ b/src/app/components/forms/sticker/FormSticker.vue
@@ -224,7 +224,7 @@ async function onClickIsActive() {
 
 	const response = await ModalConfirm.show(
 		$gettext(
-			`Are you sure you want to deactivate this sticker? When you deactivate it and save, your sticker pack will be disabled. You will need to enable it to make it available again.`
+			`Do you really want to deactivate this sticker? If you do, your sticker pack will be deactivated too. You'll need to activate the pack to make it available again.`
 		),
 		$gettext(`Deactivate Sticker`),
 		'yes'

--- a/src/app/components/forms/sticker/StickerEditModal.vue
+++ b/src/app/components/forms/sticker/StickerEditModal.vue
@@ -24,9 +24,12 @@ const props = defineProps({
 	canActivate: {
 		type: Boolean,
 	},
+	warnDeactivate: {
+		type: Boolean,
+	},
 });
 
-const { sticker, stickers, updatePack, canActivate } = toRefs(props);
+const { sticker, stickers, updatePack, canActivate, warnDeactivate } = toRefs(props);
 
 const modal = useModal()!;
 
@@ -65,6 +68,7 @@ function onPackChanged(data: StickerPack | undefined) {
 			<FormSticker
 				:model="model"
 				:can-activate="canActivate"
+				:warn-deactivate="warnDeactivate"
 				@changed="onFormChanged"
 				@pack="onPackChanged"
 			/>

--- a/src/app/components/forms/sticker/modal.service.ts
+++ b/src/app/components/forms/sticker/modal.service.ts
@@ -8,6 +8,7 @@ export async function showStickerEditModal({
 	stickers,
 	updatePack,
 	canActivate,
+	warnDeactivate,
 }: {
 	/**
 	 * Existing sticker model to be edited.
@@ -28,6 +29,11 @@ export async function showStickerEditModal({
 	 * Whether the sticker can be activated.
 	 */
 	canActivate?: boolean;
+
+	/**
+	 * Whether to show a warning message when deactivating a sticker.
+	 */
+	warnDeactivate?: boolean;
 }) {
 	return await showModal<void>({
 		modalId: 'StickerEdit',
@@ -37,6 +43,7 @@ export async function showStickerEditModal({
 			stickers,
 			updatePack,
 			canActivate,
+			warnDeactivate,
 		},
 		size: 'sm',
 	});

--- a/src/app/views/dashboard/stickers/RouteDashStickers.vue
+++ b/src/app/views/dashboard/stickers/RouteDashStickers.vue
@@ -240,12 +240,12 @@ function onPackEnabledChanged() {
 					<AppJolticon icon="exclamation-circle" big />
 					<div>
 						<div :style="{ fontWeight: 'bold' }">
-							{{ $gettext(`Your sticker pack is currently disabled!`) }}
+							{{ $gettext(`Your sticker pack is currently turned off! `) }}
 						</div>
 						<div>
 							{{
 								$gettext(
-									`You have enough active stickers to enable it again. If you don't enable your pack, people will be unable to receive or open your pack.`
+									`You can enable it again since you have enough active stickers. If you don't enable it, others won't be able to get or see your sticker pack.`
 								)
 							}}
 						</div>

--- a/src/app/views/dashboard/stickers/RouteDashStickers.vue
+++ b/src/app/views/dashboard/stickers/RouteDashStickers.vue
@@ -8,10 +8,10 @@ import AppFormGroup from '../../../../_common/form-vue/AppFormGroup.vue';
 import AppFormControlToggle from '../../../../_common/form-vue/controls/AppFormControlToggle.vue';
 import AppFormControlUpload from '../../../../_common/form-vue/controls/upload/AppFormControlUpload.vue';
 import {
-validateFilesize,
-validateImageAspectRatio,
-validateImageMaxDimensions,
-validateImageMinDimensions
+	validateFilesize,
+	validateImageAspectRatio,
+	validateImageMaxDimensions,
+	validateImageMinDimensions,
 } from '../../../../_common/form-vue/validators';
 import { showErrorGrowl } from '../../../../_common/growls/growls.service';
 import AppJolticon from '../../../../_common/jolticon/AppJolticon.vue';
@@ -20,14 +20,14 @@ import { ModelData } from '../../../../_common/model/model.service';
 import { createAppRoute, defineAppRouteOptions } from '../../../../_common/route/route-component';
 import { Screen } from '../../../../_common/screen/screen-service';
 import AppStickerPack, {
-StickerPackRatio
+	StickerPackRatio,
 } from '../../../../_common/sticker/pack/AppStickerPack.vue';
 import { StickerPack } from '../../../../_common/sticker/pack/pack.model';
 import { Sticker } from '../../../../_common/sticker/sticker.model';
 import {
-$gettext,
-$gettextInterpolate,
-$ngettext
+	$gettext,
+	$gettextInterpolate,
+	$ngettext,
 } from '../../../../_common/translate/translate.service';
 import { styleFlexCenter, styleWhen } from '../../../../_styles/mixins';
 import { kLineHeightComputed } from '../../../../_styles/variables';
@@ -158,6 +158,17 @@ const canActivateSticker = computed(
 	() => stickers.value.filter(i => i.is_active).length < maxStickerAmount.value
 );
 
+const warnDeactivateSticker = computed(() => {
+	// Don't warn if pack is already inactive.
+	if (pack.value && !pack.value.is_active) {
+		return false;
+	}
+
+	const minActiveStickers = pack.value?.payout_sticker_num ?? 3;
+	const currentActiveStickers = stickers.value.filter(i => i.is_active).length;
+	return currentActiveStickers <= minActiveStickers;
+});
+
 const stickerGridStyles = computed(() => {
 	const result: CSSProperties = {
 		display: `grid`,
@@ -172,6 +183,18 @@ const stickerGridStyles = computed(() => {
 	}
 
 	return result;
+});
+
+const showStickerPackDisabledWarning = computed(() => {
+	if (!pack.value || pack.value.is_active) {
+		return false;
+	}
+
+	// Show if the pack is inactive, and there are enough active stickers to enable it.
+	const minActiveStickers = pack.value.payout_sticker_num;
+	const currentActiveStickers = stickers.value.filter(i => i.is_active).length;
+
+	return currentActiveStickers >= minActiveStickers;
 });
 
 function updatePack(newPack: StickerPack | undefined) {
@@ -205,6 +228,30 @@ function onPackEnabledChanged() {
 	<AppShellPageBackdrop>
 		<section class="section">
 			<div class="container">
+				<div
+					v-if="showStickerPackDisabledWarning"
+					class="fill-notice well"
+					:style="{
+						display: 'flex',
+						gridGap: '16px',
+						alignItems: 'center',
+					}"
+				>
+					<AppJolticon icon="exclamation-circle" big />
+					<div>
+						<div :style="{ fontWeight: 'bold' }">
+							{{ $gettext(`Your sticker pack is currently disabled!`) }}
+						</div>
+						<div>
+							{{
+								$gettext(
+									`You have enough active stickers to enable it again. If you don't enable your pack, people will be unable to receive or open your pack.`
+								)
+							}}
+						</div>
+					</div>
+				</div>
+
 				<div>
 					<h1
 						:style="{
@@ -245,6 +292,7 @@ function onPackEnabledChanged() {
 								:sticker="sticker"
 								:stickers="stickers"
 								:can-activate="canActivateSticker"
+								:warn-deactivate="warnDeactivateSticker"
 								show-name
 								@pack="updatePack"
 							/>

--- a/src/app/views/dashboard/stickers/_edit/AppStickerEditTile.vue
+++ b/src/app/views/dashboard/stickers/_edit/AppStickerEditTile.vue
@@ -31,9 +31,12 @@ const props = defineProps({
 	canActivate: {
 		type: Boolean,
 	},
+	warnDeactivate: {
+		type: Boolean,
+	},
 });
 
-const { sticker, stickers, showName, canActivate } = toRefs(props);
+const { sticker, stickers, showName, canActivate, warnDeactivate } = toRefs(props);
 
 const emit = defineEmits({
 	pack: (_payloadPack: StickerPack | undefined) => true,
@@ -47,6 +50,7 @@ function onClickTile() {
 		stickers: stickers?.value,
 		updatePack: pack => emit('pack', pack),
 		canActivate: canActivate?.value,
+		warnDeactivate: warnDeactivate?.value,
 	});
 }
 </script>


### PR DESCRIPTION
Warn messaging for creator pack deactivation:
 - disabling sticker that would lead to pack's deactivation shows confirm modal
 - warning banner when pack is inactive but can be activated