### PR TITLE
Fix chat room appearing twice in list

### DIFF
--- a/src/app/components/chat/user-channel.ts
+++ b/src/app/components/chat/user-channel.ts
@@ -5,7 +5,7 @@ import type { TabLeaderInterface } from '../../../utils/tab-leader';
 import { Background } from '../../../_common/background/background.model';
 import { importNoSSR } from '../../../_common/code-splitting';
 import { ContentFocus } from '../../../_common/content-focus/content-focus.service';
-import { getModel, storeModel } from '../../../_common/model/model-store.service';
+import { storeModel } from '../../../_common/model/model-store.service';
 import { UnknownModelData } from '../../../_common/model/model.service';
 import { createSocketChannelController } from '../../../_common/socket/socket-controller';
 import {
@@ -221,12 +221,10 @@ export function createChatUserChannel(
 	}
 
 	function _onGroupAdd(data: GroupAddPayload) {
-		const roomId = data.room.id as number;
-		const existingGroup = getModel(ChatRoom, roomId);
 		const newGroup = storeModel(ChatRoom, { chat: client, ...data.room });
 
 		// Only push to room list if it's not already there.
-		if (!existingGroup) {
+		if (client.groupRooms.every(x => x.id !== newGroup.id)) {
 			client.groupRooms.push(newGroup);
 		}
 	}

--- a/src/app/components/chat/user-channel.ts
+++ b/src/app/components/chat/user-channel.ts
@@ -5,7 +5,7 @@ import type { TabLeaderInterface } from '../../../utils/tab-leader';
 import { Background } from '../../../_common/background/background.model';
 import { importNoSSR } from '../../../_common/code-splitting';
 import { ContentFocus } from '../../../_common/content-focus/content-focus.service';
-import { storeModel } from '../../../_common/model/model-store.service';
+import { getModel, storeModel } from '../../../_common/model/model-store.service';
 import { UnknownModelData } from '../../../_common/model/model.service';
 import { createSocketChannelController } from '../../../_common/socket/socket-controller';
 import {
@@ -221,8 +221,14 @@ export function createChatUserChannel(
 	}
 
 	function _onGroupAdd(data: GroupAddPayload) {
+		const roomId = data.room.id as number;
+		const existingGroup = getModel(ChatRoom, roomId);
 		const newGroup = storeModel(ChatRoom, { chat: client, ...data.room });
-		client.groupRooms.push(newGroup);
+
+		// Only push to room list if it's not already there.
+		if (!existingGroup) {
+			client.groupRooms.push(newGroup);
+		}
 	}
 
 	function _onUpdateTitle(data: UpdateGroupTitlePayload) {


### PR DESCRIPTION
Bug: When accepting an invite to the same room, the room will appear twice in the list until refresh.
Fix by checking if the room is already in the list.