### PR TITLE
Track user timezone

### DIFF
--- a/src/_common/api/api.service.ts
+++ b/src/_common/api/api.service.ts
@@ -1,5 +1,6 @@
 import Axios, { AxiosRequestConfig } from 'axios';
 import { ref } from 'vue';
+import { setTimezoneOffsetCookie } from '../cookie/cookie.service';
 import { Environment } from '../environment/environment.service';
 import { Payload } from '../payload/payload-service';
 
@@ -297,6 +298,9 @@ export class Api {
 		if (!requestInfo.method) {
 			requestInfo.method = requestInfo.data ? 'POST' : 'GET';
 		}
+
+		// Update the timezone cookie for every request.
+		setTimezoneOffsetCookie();
 
 		return Axios(requestInfo);
 	}

--- a/src/_common/bootstrap.ts
+++ b/src/_common/bootstrap.ts
@@ -7,14 +7,15 @@ import AppButton from './button/AppButton.vue';
 import { initSafeExportsForClient as initCommonSafeExportsForClient } from './client/safe-exports';
 import { ensureConfig } from './config/config.service';
 import { initConnectionService } from './connection/connection-service';
+import { setTimezoneOffsetCookie } from './cookie/cookie.service';
 import AppJolticon from './jolticon/AppJolticon.vue';
 import AppLinkExternal from './link/AppLinkExternal.vue';
 import AppLinkHelp from './link/AppLinkHelp.vue';
 import { initMetaService } from './meta/meta-service';
 import { Payload } from './payload/payload-service';
 import { Referrer } from './referrer/referrer.service';
-import { commonStore, CommonStoreKey } from './store/common-store';
-import { createThemeStore, ThemeStoreKey } from './theme/theme.store';
+import { CommonStoreKey, commonStore } from './store/common-store';
+import { ThemeStoreKey, createThemeStore } from './theme/theme.store';
 import { initTranslations } from './translate/translate.service';
 
 export type BootstrapOptions<T = Component> = {
@@ -66,6 +67,7 @@ export async function bootstrapCommon(options: BootstrapOptions) {
 	initAnalytics({ commonStore });
 	Payload.init({ commonStore });
 	initConnectionService({ commonStore });
+	setTimezoneOffsetCookie();
 
 	if (router) {
 		initMetaService(router);

--- a/src/_common/cookie/banner/banner.vue
+++ b/src/_common/cookie/banner/banner.vue
@@ -1,6 +1,11 @@
 <script lang="ts">
 import { Options, Vue } from 'vue-property-decorator';
 import { Environment } from '../../environment/environment.service';
+import {
+	setTimezoneOffsetCookie,
+	setUserAgreedToCookies,
+	userAgreedToCookies,
+} from '../cookie.service';
 
 @Options({})
 export default class AppCookieBanner extends Vue {
@@ -13,12 +18,15 @@ export default class AppCookieBanner extends Vue {
 			return false;
 		}
 
-		return !this.forceClosed && !window.localStorage.getItem('banner:cookie');
+		return !this.forceClosed && !userAgreedToCookies();
 	}
 
 	close() {
 		this.forceClosed = true;
-		window.localStorage.setItem('banner:cookie', Date.now() + '');
+		setUserAgreedToCookies();
+
+		// Might as well set the timezone offset cookie once we have permission.
+		setTimezoneOffsetCookie();
 	}
 }
 </script>

--- a/src/_common/cookie/cookie.service.ts
+++ b/src/_common/cookie/cookie.service.ts
@@ -31,3 +31,31 @@ export function getCookie(name: string): Promise<string | undefined> {
 		}
 	});
 }
+
+export function userAgreedToCookies() {
+	return !!window.localStorage.getItem('banner:cookie');
+}
+
+export function setUserAgreedToCookies() {
+	window.localStorage.setItem('banner:cookie', Date.now() + '');
+}
+
+export function setTimezoneOffsetCookie() {
+	// Only track if user agreed to cookies.
+	if (!userAgreedToCookies()) {
+		return;
+	}
+
+	const cookieName = 'gjtz';
+
+	// Negate the offset, because this function returns the offset from UTC to local time.
+	// Example, UTC offset +01:00 is -3600 seconds.
+	// But we want to know how far away a user's timezone is from UTC, so we want 3600.
+	// * 60 to turn from minutes to seconds.
+	const offsetSeconds = new Date().getTimezoneOffset() * -60;
+
+	const expiresTimestamp = Date.now() + 1000 * 60 * 60 * 24 * 7;
+	const expires = new Date(expiresTimestamp).toUTCString();
+
+	document.cookie = `${cookieName}=${offsetSeconds}; expires=${expires}; path=/`;
+}

--- a/src/_common/quest/quest-model.ts
+++ b/src/_common/quest/quest-model.ts
@@ -1,3 +1,4 @@
+import { getCurrentServerTime } from '../../utils/server-time';
 import { MediaItem } from '../media-item/media-item-model';
 import { Model } from '../model/model.service';
 import { QuestObjective } from './quest-objective-model';
@@ -85,7 +86,7 @@ export class Quest extends Model {
 			return true;
 		}
 
-		return !!this.ends_on && this.ends_on < Date.now();
+		return !!this.ends_on && this.ends_on < getCurrentServerTime();
 	}
 
 	get isIncomplete() {

--- a/src/app/components/grid/notification-channel.ts
+++ b/src/app/components/grid/notification-channel.ts
@@ -1,11 +1,11 @@
 import { computed, reactive, shallowReadonly } from 'vue';
-import { TabLeaderInterface } from '../../../utils/tab-leader';
 import { importNoSSR } from '../../../_common/code-splitting';
 import { FiresidePostGotoGrowl } from '../../../_common/fireside/post/goto-growl/goto-growl.service';
 import { FiresidePost } from '../../../_common/fireside/post/post-model';
 import { Notification } from '../../../_common/notification/notification-model';
 import { QuestNotification } from '../../../_common/quest/quest-notification-model';
 import { createSocketChannelController } from '../../../_common/socket/socket-controller';
+import { TabLeaderInterface } from '../../../utils/tab-leader';
 import { shouldUseFYPDefault } from '../../views/home/home-feed.service';
 import { GridClient, onFiresideStart } from './client.service';
 
@@ -35,7 +35,6 @@ interface JoinPayload {
 	unreadCommunities: number[];
 	newQuestIds: number[];
 	questActivityIds: number[];
-	questResetHour: number;
 	charge: ChargeData;
 }
 
@@ -130,7 +129,6 @@ export function createGridNotificationChannel(client: GridClient, options: { use
 			const questStore = appStore.getQuestStore();
 			questStore.addNewQuestIds(payload.newQuestIds);
 			questStore.addQuestActivityIds(payload.questActivityIds);
-			questStore.setDailyResetHour(payload.questResetHour);
 
 			const {
 				charge,

--- a/src/app/components/quest/AppQuestTimer.vue
+++ b/src/app/components/quest/AppQuestTimer.vue
@@ -1,38 +1,31 @@
 <script lang="ts">
 import { computed, onMounted, onUnmounted, ref, toRefs } from 'vue';
-import { getCurrentServerTime } from '../../../utils/server-time';
 import { shorthandReadableTime } from '../../../_common/filters/duration';
 import AppJolticon from '../../../_common/jolticon/AppJolticon.vue';
 import AppTranslate from '../../../_common/translate/AppTranslate.vue';
+import { getCurrentServerTime } from '../../../utils/server-time';
 </script>
 
 <script lang="ts" setup>
 const props = defineProps({
-	date: {
+	endsOn: {
 		type: Number,
 		required: true,
 	},
-	ended: {
-		type: Boolean,
-		default: undefined,
-	},
 });
 
-const { date, ended } = toRefs(props);
+const { endsOn } = toRefs(props);
 
 const currentTime = ref(getCurrentServerTime());
 const readableTime = ref(getReadableTime());
 let interval: NodeJS.Timer | null = null;
 
-const hasEnded = computed(() => {
-	if (ended?.value === undefined) {
-		return date.value - currentTime.value <= 0;
-	}
-	return ended.value;
-});
+const hasEnded = computed(() => endsOn.value - currentTime.value <= 0);
 
 onMounted(() => {
-	interval = setInterval(() => updateTimer(), 1000);
+	if (!interval) {
+		interval = setInterval(updateTimer, 1_000);
+	}
 	updateTimer();
 });
 
@@ -44,7 +37,7 @@ onUnmounted(() => {
 });
 
 function getReadableTime() {
-	return shorthandReadableTime(date.value, {
+	return shorthandReadableTime(endsOn.value, {
 		allowFuture: true,
 		precision: 'rough',
 		joiner: ', ',
@@ -64,7 +57,7 @@ function updateTimer() {
 			<AppTranslate class="text-muted"> This quest has ended </AppTranslate>
 		</slot>
 	</span>
-	<span v-else-if="date">
+	<span v-else-if="endsOn">
 		<AppJolticon class="small text-muted" icon="clock" />
 		<span class="text-muted">
 			{{ ' ' + readableTime }}

--- a/src/app/views/quests/view/RouteQuestsView.vue
+++ b/src/app/views/quests/view/RouteQuestsView.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { computed, ref } from 'vue';
 import { RouterLink } from 'vue-router';
-import { numberSort } from '../../../../utils/array';
 import { Api } from '../../../../_common/api/api.service';
 import AppContentViewer from '../../../../_common/content/content-viewer/AppContentViewer.vue';
 import AppImgResponsive from '../../../../_common/img/AppImgResponsive.vue';
@@ -19,6 +18,7 @@ import AppTranslate from '../../../../_common/translate/AppTranslate.vue';
 import { $gettext, $gettextInterpolate } from '../../../../_common/translate/translate.service';
 import AppUserAvatarList from '../../../../_common/user/user-avatar/list/list.vue';
 import { User } from '../../../../_common/user/user.model';
+import { numberSort } from '../../../../utils/array';
 import AppQuestTimer from '../../../components/quest/AppQuestTimer.vue';
 import { useQuestStore } from '../../../store/quest';
 
@@ -202,7 +202,7 @@ function onNewQuest(data: Quest) {
 					<div class="-quest-type">{{ quest.questType }}</div>
 					<div class="-quest-title">{{ quest.title }}</div>
 					<template v-if="quest.ends_on">
-						<AppQuestTimer :date="quest.ends_on" />
+						<AppQuestTimer :ends-on="quest.ends_on" />
 					</template>
 				</div>
 				<AppSpacer vertical :scale="4" />


### PR DESCRIPTION
Introduce a `gjtz` cookie to track a user's local timezone offset.
This can then be used to localize certain timed events, such as daily/weekly quest expiration times.