### PR TITLE
Optimize channel joins

### DIFF
--- a/src/app/components/chat/_list/AppChatList.vue
+++ b/src/app/components/chat/_list/AppChatList.vue
@@ -16,7 +16,11 @@ function searchEntries<T extends ChatListEntry>(entries: T[], query: string): T[
 				fuzzysearch(query, i.username.toLowerCase())
 			);
 		} else if (i instanceof ChatRoom) {
-			return searchEntries(i.memberCollection.users, query).length > 0;
+			if (i.title) {
+				return fuzzysearch(query, i.title.toLowerCase());
+			} else {
+				return i.fallback_title && fuzzysearch(query, i.fallback_title.toLowerCase());
+			}
 		}
 	});
 }

--- a/src/app/components/chat/room-channel.ts
+++ b/src/app/components/chat/room-channel.ts
@@ -361,8 +361,9 @@ export function createChatRoomChannel(
 	}
 
 	function _onRoomUpdate(json: Partial<ChatRoom>) {
-		const { title, background } = json;
+		const { title, fallback_title, background } = json;
 		room.value.title = title || '';
+		room.value.fallback_title = fallback_title || '';
 		room.value.background = background ? new Background(background) : undefined;
 	}
 

--- a/src/app/components/chat/room-channel.ts
+++ b/src/app/components/chat/room-channel.ts
@@ -522,7 +522,7 @@ export function createChatRoomChannel(
 	 * Adds new members to this room.
 	 */
 	function pushMemberAdd(members: number[]) {
-		return channelController.push<void>('invite_new_member', { member_ids: members });
+		return channelController.push<void>('member_add', { member_ids: members });
 	}
 
 	/**

--- a/src/app/components/chat/room-channel.ts
+++ b/src/app/components/chat/room-channel.ts
@@ -521,7 +521,7 @@ export function createChatRoomChannel(
 	 * Adds new members to this room.
 	 */
 	function pushMemberAdd(members: number[]) {
-		return channelController.push<void>('member_add', { member_ids: members });
+		return channelController.push<void>('invite_new_member', { member_ids: members });
 	}
 
 	/**

--- a/src/app/components/chat/room.ts
+++ b/src/app/components/chat/room.ts
@@ -24,6 +24,7 @@ export class ChatRoom implements ModelStoreModel {
 
 	declare id: number;
 	declare title: string;
+	declare fallback_title: string;
 	declare type: ChatRoomType;
 	declare user?: ChatUser;
 	declare roles: ChatRole[];
@@ -174,17 +175,9 @@ export function getChatRoomTitle(room: ChatRoom) {
 		return room.title;
 	}
 
-	// When no title is set and no/one member is in the chat, set the title
-	// to "Group Chat" instead of just the single name.
-	if (room.memberCollection.count <= 1) {
-		return $gettext(`Group Chat`);
+	if (room.fallback_title) {
+		return room.fallback_title;
 	}
 
-	// No room title, return a comma separated list of members.
-	const chat = room.chat;
-	return room.memberCollection.users
-		.filter(i => i.id !== chat.currentUser?.id)
-		.slice(0, 5)
-		.map(i => i.display_name)
-		.join(', ');
+	return $gettext(`Group Chat`);
 }


### PR DESCRIPTION
Send "invite_new_member"  instead of "member_add" when inviting new member to an existing group