### PR TITLE
Fixed a minor error in the linux_64 sort

### DIFF
--- a/src/_common/game/build/build.model.ts
+++ b/src/_common/game/build/build.model.ts
@@ -98,7 +98,7 @@ export const GameBuildPlatformSupportInfo: { [k: string]: PlatformSupport } = {
 		icon: 'linux',
 		tooltip: 'Linux 64-bit',
 		arch: '64',
-		sort: 30,
+		sort: 31,
 	},
 	other: {
 		icon: 'other-os',


### PR DESCRIPTION
It's pretty self-explanatory if you look at the sorts of windows and macos and their 64 counterparts